### PR TITLE
Allow more concurrent HEAD requests

### DIFF
--- a/src/openneuro/_download.py
+++ b/src/openneuro/_download.py
@@ -388,9 +388,6 @@ async def _attempt_download(
         # Phase 1: HEAD request to get remote file hash and size.
         # The file sizes provided via the API often do not match the sizes
         # reported by the HTTP server. Rely on the HTTP server sizes.
-        # HEAD requests use a separate semaphore with a higher limit than
-        # file downloads — they return tiny responses and should not compete
-        # with actual file downloads for concurrency slots.
         try:
             async with head_semaphore:
                 response = await client.head(url, headers=user_agent_header)

--- a/src/openneuro/_download.py
+++ b/src/openneuro/_download.py
@@ -94,6 +94,8 @@ allowed_retry_exceptions = (
 )
 user_agent_header: dict[str, str] = {"user-agent": f"openneuro-py/{__version__}"}
 
+_MAX_CONCURRENT_HEAD_REQUESTS = 50
+
 # GraphQL endpoint and queries.
 
 gql_url = "https://openneuro.org/crn/graphql"
@@ -602,7 +604,7 @@ async def _download_files(
     semaphore = asyncio.Semaphore(max_concurrent_downloads)
     # HEAD requests use a separate, higher-limit semaphore so they complete
     # quickly without blocking file downloads.
-    head_semaphore = asyncio.Semaphore(50)
+    head_semaphore = asyncio.Semaphore(_MAX_CONCURRENT_HEAD_REQUESTS)
     download_tasks = []
     normalized_query_str = " ".join(shlex.split(query_str, posix=False))
 

--- a/src/openneuro/_download.py
+++ b/src/openneuro/_download.py
@@ -313,6 +313,7 @@ async def _download_file(
     max_retries: int,
     retry_backoff: float,
     semaphore: asyncio.Semaphore,
+    head_semaphore: asyncio.Semaphore,
     query_str: str,
 ) -> None:
     """Download an individual file, retrying on transient errors."""
@@ -325,6 +326,7 @@ async def _download_file(
                 verify_hash=verify_hash,
                 verify_size=verify_size,
                 semaphore=semaphore,
+                head_semaphore=head_semaphore,
                 query_str=query_str,
             )
             return
@@ -359,6 +361,7 @@ async def _attempt_download(
     verify_hash: bool,
     verify_size: bool,
     semaphore: asyncio.Semaphore,
+    head_semaphore: asyncio.Semaphore,
     query_str: str,
 ) -> None:
     """Single download attempt (HEAD → local check → GET)."""
@@ -385,12 +388,13 @@ async def _attempt_download(
         # Phase 1: HEAD request to get remote file hash and size.
         # The file sizes provided via the API often do not match the sizes
         # reported by the HTTP server. Rely on the HTTP server sizes.
-        # HEAD requests are not gated by the semaphore — they return tiny
-        # responses and should not compete with actual file downloads for
-        # concurrency slots.
+        # HEAD requests use a separate semaphore with a higher limit than
+        # file downloads — they return tiny responses and should not compete
+        # with actual file downloads for concurrency slots.
         try:
-            response = await client.head(url, headers=user_agent_header)
-            headers = response.headers
+            async with head_semaphore:
+                response = await client.head(url, headers=user_agent_header)
+                headers = response.headers
         except allowed_retry_exceptions as exc:
             raise _RetryableError from exc
 
@@ -599,6 +603,9 @@ async def _download_files(
     # Semaphore (counter) to limit maximum number of concurrent download
     # coroutines.
     semaphore = asyncio.Semaphore(max_concurrent_downloads)
+    # HEAD requests use a separate, higher-limit semaphore so they complete
+    # quickly without blocking file downloads.
+    head_semaphore = asyncio.Semaphore(50)
     download_tasks = []
     normalized_query_str = " ".join(shlex.split(query_str, posix=False))
 
@@ -623,6 +630,7 @@ async def _download_files(
             max_retries=max_retries,
             retry_backoff=retry_backoff,
             semaphore=semaphore,
+            head_semaphore=head_semaphore,
             query_str=normalized_query_str,
         )
         download_tasks.append(download_task)

--- a/src/openneuro/_download.py
+++ b/src/openneuro/_download.py
@@ -385,10 +385,12 @@ async def _attempt_download(
         # Phase 1: HEAD request to get remote file hash and size.
         # The file sizes provided via the API often do not match the sizes
         # reported by the HTTP server. Rely on the HTTP server sizes.
+        # HEAD requests are not gated by the semaphore — they return tiny
+        # responses and should not compete with actual file downloads for
+        # concurrency slots.
         try:
-            async with semaphore:
-                response = await client.head(url, headers=user_agent_header)
-                headers = response.headers
+            response = await client.head(url, headers=user_agent_header)
+            headers = response.headers
         except allowed_retry_exceptions as exc:
             raise _RetryableError from exc
 

--- a/src/openneuro/_download.py
+++ b/src/openneuro/_download.py
@@ -393,6 +393,13 @@ async def _attempt_download(
         try:
             async with head_semaphore:
                 response = await client.head(url, headers=user_agent_header)
+                if response.status_code in allowed_retry_codes:
+                    raise _RetryableError
+                if response.is_error:
+                    raise RuntimeError(
+                        f"HEAD request failed with HTTP "
+                        f"{response.status_code} for {url}"
+                    )
                 headers = response.headers
         except allowed_retry_exceptions as exc:
             raise _RetryableError from exc

--- a/src/openneuro/_download.py
+++ b/src/openneuro/_download.py
@@ -394,7 +394,7 @@ async def _attempt_download(
             async with head_semaphore:
                 response = await client.head(url, headers=user_agent_header)
                 if response.status_code in allowed_retry_codes:
-                    raise _RetryableError
+                    raise _RetryableError(f"HTTP {response.status_code}")
                 if response.is_error:
                     raise RuntimeError(
                         f"HEAD request failed with HTTP "

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -830,6 +830,7 @@ def test_semaphore_not_leaked_on_retry(tmp_path: Path):
     on every retry.
     """
     semaphore = asyncio.Semaphore(2)
+    head_semaphore = asyncio.Semaphore(50)
     mock_client = _make_fake_client(file_content=b"hello", fail_head_n_times=1)
 
     async def run():
@@ -842,6 +843,7 @@ def test_semaphore_not_leaked_on_retry(tmp_path: Path):
             max_retries=3,
             retry_backoff=0.0,
             semaphore=semaphore,
+            head_semaphore=head_semaphore,
             query_str="test query",
         )
 

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -830,7 +830,7 @@ def test_semaphore_not_leaked_on_retry(tmp_path: Path):
     on every retry.
     """
     semaphore = asyncio.Semaphore(2)
-    head_semaphore = asyncio.Semaphore(50)
+    head_semaphore = asyncio.Semaphore(_download._MAX_CONCURRENT_HEAD_REQUESTS)
     mock_client = _make_fake_client(file_content=b"hello", fail_head_n_times=1)
 
     async def run():
@@ -853,6 +853,8 @@ def test_semaphore_not_leaked_on_retry(tmp_path: Path):
     assert semaphore._value == 2, (
         f"Semaphore leaked: expected value 2, got {semaphore._value}"
     )
-    assert head_semaphore._value == 50, (
-        f"HEAD semaphore leaked: expected value 50, got {head_semaphore._value}"
+    assert head_semaphore._value == _download._MAX_CONCURRENT_HEAD_REQUESTS, (
+        f"HEAD semaphore leaked: expected value "
+        f"{_download._MAX_CONCURRENT_HEAD_REQUESTS}, "
+        f"got {head_semaphore._value}"
     )

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -853,3 +853,6 @@ def test_semaphore_not_leaked_on_retry(tmp_path: Path):
     assert semaphore._value == 2, (
         f"Semaphore leaked: expected value 2, got {semaphore._value}"
     )
+    assert head_semaphore._value == 50, (
+        f"HEAD semaphore leaked: expected value 50, got {head_semaphore._value}"
+    )

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -772,6 +772,8 @@ def _make_fake_client(*, file_content: bytes, fail_head_n_times: int = 0):
         if head_call_count <= fail_head_n_times:
             raise httpx.ReadTimeout("simulated timeout")
         resp = MagicMock()
+        resp.status_code = 200
+        resp.is_error = False
         resp.headers = {
             "etag": '"d41d8cd98f00b204e9800998ecf8427e"',
             "content-length": str(len(file_content)),

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -752,7 +752,12 @@ def test_safe_query_raises_on_non_retryable_non_json():
         _download._safe_query("query { test }")
 
 
-def _make_fake_client(*, file_content: bytes, fail_head_n_times: int = 0):
+def _make_fake_client(
+    *,
+    file_content: bytes,
+    fail_head_n_times: int = 0,
+    fail_head_status_code: int | None = None,
+):
     """Create a mock ``httpx.AsyncClient`` for download tests.
 
     Parameters
@@ -760,8 +765,10 @@ def _make_fake_client(*, file_content: bytes, fail_head_n_times: int = 0):
     file_content
         Bytes the fake GET response will yield.
     fail_head_n_times
-        Number of initial HEAD requests that raise ``httpx.ReadTimeout``
-        before succeeding.
+        Number of initial HEAD requests that fail before succeeding.
+    fail_head_status_code
+        If set, failing HEAD requests return this HTTP status code instead
+        of raising ``httpx.ReadTimeout``.
 
     """
     head_call_count = 0
@@ -770,6 +777,12 @@ def _make_fake_client(*, file_content: bytes, fail_head_n_times: int = 0):
         nonlocal head_call_count
         head_call_count += 1
         if head_call_count <= fail_head_n_times:
+            if fail_head_status_code is not None:
+                resp = MagicMock()
+                resp.status_code = fail_head_status_code
+                resp.is_error = fail_head_status_code >= 400
+                resp.headers = {}
+                return resp
             raise httpx.ReadTimeout("simulated timeout")
         resp = MagicMock()
         resp.status_code = 200
@@ -860,3 +873,63 @@ def test_semaphore_not_leaked_on_retry(tmp_path: Path):
         f"{_download._MAX_CONCURRENT_HEAD_REQUESTS}, "
         f"got {head_semaphore._value}"
     )
+
+
+def test_head_retryable_status_code(tmp_path: Path):
+    """A retryable HEAD status code (e.g. 503) should be retried."""
+    semaphore = asyncio.Semaphore(2)
+    head_semaphore = asyncio.Semaphore(_download._MAX_CONCURRENT_HEAD_REQUESTS)
+    mock_client = _make_fake_client(
+        file_content=b"hello",
+        fail_head_n_times=1,
+        fail_head_status_code=503,
+    )
+
+    async def run():
+        await _download_file(
+            url="https://example.com/test.txt",
+            api_file_size=5,
+            outfile=tmp_path / "test.txt",
+            verify_hash=False,
+            verify_size=False,
+            max_retries=3,
+            retry_backoff=0.0,
+            semaphore=semaphore,
+            head_semaphore=head_semaphore,
+            query_str="test query",
+        )
+
+    with patch("openneuro._download.httpx.AsyncClient", return_value=mock_client):
+        asyncio.run(run())
+
+    # The file should have been downloaded successfully after the retry.
+    assert (tmp_path / "test.txt").read_bytes() == b"hello"
+
+
+def test_head_non_retryable_status_code(tmp_path: Path):
+    """A non-retryable HEAD status code (e.g. 404) should raise RuntimeError."""
+    semaphore = asyncio.Semaphore(2)
+    head_semaphore = asyncio.Semaphore(_download._MAX_CONCURRENT_HEAD_REQUESTS)
+    mock_client = _make_fake_client(
+        file_content=b"hello",
+        fail_head_n_times=99,
+        fail_head_status_code=404,
+    )
+
+    async def run():
+        await _download_file(
+            url="https://example.com/test.txt",
+            api_file_size=5,
+            outfile=tmp_path / "test.txt",
+            verify_hash=False,
+            verify_size=False,
+            max_retries=3,
+            retry_backoff=0.0,
+            semaphore=semaphore,
+            head_semaphore=head_semaphore,
+            query_str="test query",
+        )
+
+    with patch("openneuro._download.httpx.AsyncClient", return_value=mock_client):
+        with pytest.raises(RuntimeError, match="HEAD request failed with HTTP 404"):
+            asyncio.run(run())

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -836,17 +836,18 @@ def test_max_concurrent_downloads_cli_validation():
     assert result.exit_code == 2
 
 
-def test_semaphore_not_leaked_on_retry(tmp_path: Path):
-    """Semaphore value must be preserved after retries.
-
-    Regression test: the old recursive _retry_download() would call
-    semaphore.release() explicitly, then the enclosing ``async with
-    semaphore:`` would release again on exit — inflating the counter
-    on every retry.
-    """
-    semaphore = asyncio.Semaphore(2)
-    head_semaphore = asyncio.Semaphore(_download._MAX_CONCURRENT_HEAD_REQUESTS)
-    mock_client = _make_fake_client(file_content=b"hello", fail_head_n_times=1)
+def _run_download_file(
+    tmp_path: Path,
+    mock_client: AsyncMock,
+    *,
+    semaphore: asyncio.Semaphore | None = None,
+    head_semaphore: asyncio.Semaphore | None = None,
+) -> None:
+    """Run ``_download_file`` with a mocked ``httpx.AsyncClient``."""
+    if semaphore is None:
+        semaphore = asyncio.Semaphore(2)
+    if head_semaphore is None:
+        head_semaphore = asyncio.Semaphore(_download._MAX_CONCURRENT_HEAD_REQUESTS)
 
     async def run():
         await _download_file(
@@ -864,6 +865,26 @@ def test_semaphore_not_leaked_on_retry(tmp_path: Path):
 
     with patch("openneuro._download.httpx.AsyncClient", return_value=mock_client):
         asyncio.run(run())
+
+
+def test_semaphore_not_leaked_on_retry(tmp_path: Path):
+    """Semaphore value must be preserved after retries.
+
+    Regression test: the old recursive _retry_download() would call
+    semaphore.release() explicitly, then the enclosing ``async with
+    semaphore:`` would release again on exit — inflating the counter
+    on every retry.
+    """
+    semaphore = asyncio.Semaphore(2)
+    head_semaphore = asyncio.Semaphore(_download._MAX_CONCURRENT_HEAD_REQUESTS)
+    mock_client = _make_fake_client(file_content=b"hello", fail_head_n_times=1)
+
+    _run_download_file(
+        tmp_path,
+        mock_client,
+        semaphore=semaphore,
+        head_semaphore=head_semaphore,
+    )
 
     assert semaphore._value == 2, (
         f"Semaphore leaked: expected value 2, got {semaphore._value}"
@@ -877,59 +898,24 @@ def test_semaphore_not_leaked_on_retry(tmp_path: Path):
 
 def test_head_retryable_status_code(tmp_path: Path):
     """A retryable HEAD status code (e.g. 503) should be retried."""
-    semaphore = asyncio.Semaphore(2)
-    head_semaphore = asyncio.Semaphore(_download._MAX_CONCURRENT_HEAD_REQUESTS)
     mock_client = _make_fake_client(
         file_content=b"hello",
         fail_head_n_times=1,
         fail_head_status_code=503,
     )
 
-    async def run():
-        await _download_file(
-            url="https://example.com/test.txt",
-            api_file_size=5,
-            outfile=tmp_path / "test.txt",
-            verify_hash=False,
-            verify_size=False,
-            max_retries=3,
-            retry_backoff=0.0,
-            semaphore=semaphore,
-            head_semaphore=head_semaphore,
-            query_str="test query",
-        )
+    _run_download_file(tmp_path, mock_client)
 
-    with patch("openneuro._download.httpx.AsyncClient", return_value=mock_client):
-        asyncio.run(run())
-
-    # The file should have been downloaded successfully after the retry.
     assert (tmp_path / "test.txt").read_bytes() == b"hello"
 
 
 def test_head_non_retryable_status_code(tmp_path: Path):
     """A non-retryable HEAD status code (e.g. 404) should raise RuntimeError."""
-    semaphore = asyncio.Semaphore(2)
-    head_semaphore = asyncio.Semaphore(_download._MAX_CONCURRENT_HEAD_REQUESTS)
     mock_client = _make_fake_client(
         file_content=b"hello",
         fail_head_n_times=99,
         fail_head_status_code=404,
     )
 
-    async def run():
-        await _download_file(
-            url="https://example.com/test.txt",
-            api_file_size=5,
-            outfile=tmp_path / "test.txt",
-            verify_hash=False,
-            verify_size=False,
-            max_retries=3,
-            retry_backoff=0.0,
-            semaphore=semaphore,
-            head_semaphore=head_semaphore,
-            query_str="test query",
-        )
-
-    with patch("openneuro._download.httpx.AsyncClient", return_value=mock_client):
-        with pytest.raises(RuntimeError, match="HEAD request failed with HTTP 404"):
-            asyncio.run(run())
+    with pytest.raises(RuntimeError, match="HEAD request failed with HTTP 404"):
+        _run_download_file(tmp_path, mock_client)


### PR DESCRIPTION
This allows the actual downloads to start on my system after about a second as compared to 30 seconds before (I don't have the exact numbers now, but the order of magnitude is about correct).

**Detailed explanation:**
When doing:

```shell
uv run openneuro-py download --dataset=ds003104 --no-verify-size --target-dir=/tmp/ds003104
```
I would now (after #310) almost immediately see:

```
🌍 Preparing to download ds003104 …
📥 Retrieving up to 602 files (5 concurrent downloads). 
```
And I would get immediate network traffic of about 100–400 kB/s – but no files would actually download for 30 or more seconds!

Turns out the problem was how we handled the HEAD requests (we use those to retrieve file sizes and hashes from S3 servers): HEAD requests were gated by the same semaphore as GET downloads (5 slots), causing all ~600 HEAD requests to serialize before file downloads could begin – resulting in that ~30-second stall with no visible progress!

Considering that HEAD responses are tiny, I figured they don't need concurrency limiting, so I <strike>removed it</strike> set it to 50. The GET download semaphore remains unchanged.

Now dataset downloads start super fast!

This also adds response error checking for HEAD. We had somehow forgotten about this before.

@larsoner You're gonna love this!