### PR TITLE
Use dataset-relative paths in download error messages

### DIFF
--- a/src/openneuro/_download.py
+++ b/src/openneuro/_download.py
@@ -322,6 +322,7 @@ async def _download_file(
     url: str,
     api_file_size: int | None,
     outfile: Path,
+    dataset_path: str,
     verify_hash: bool,
     verify_size: bool,
     max_retries: int,
@@ -337,6 +338,7 @@ async def _download_file(
                 url=url,
                 api_file_size=api_file_size,
                 outfile=outfile,
+                dataset_path=dataset_path,
                 verify_hash=verify_hash,
                 verify_size=verify_size,
                 semaphore=semaphore,
@@ -353,7 +355,7 @@ async def _download_file(
                 else:
                     reason = str(err) or "Error"
                 _write_retry(
-                    what=f"downloading {outfile}",
+                    what=f"downloading {dataset_path}",
                     reason=reason,
                     retry=max_retries - attempt,
                     backoff=retry_backoff,
@@ -362,7 +364,7 @@ async def _download_file(
                 retry_backoff *= 2
             else:
                 raise RuntimeError(
-                    f"Failed to download {outfile} from {url} "
+                    f"Failed to download {dataset_path} from {url} "
                     f"after {max_retries} retries."
                 ) from (err.__cause__ or err)
 
@@ -372,6 +374,7 @@ async def _attempt_download(
     url: str,
     api_file_size: int | None,
     outfile: Path,
+    dataset_path: str,
     verify_hash: bool,
     verify_size: bool,
     semaphore: asyncio.Semaphore,
@@ -528,6 +531,7 @@ async def _attempt_download(
                     await _retrieve_and_write_to_disk(
                         response=response,
                         outfile=outfile,
+                        dataset_path=dataset_path,
                         mode=mode,
                         desc=desc,
                         local_file_size=local_file_size,
@@ -544,6 +548,7 @@ async def _retrieve_and_write_to_disk(
     *,
     response: httpx.Response,
     outfile: Path,
+    dataset_path: str,
     mode: Literal["ab", "wb"],
     desc: str,
     local_file_size: int,
@@ -587,7 +592,7 @@ async def _retrieve_and_write_to_disk(
             got = hash.hexdigest()
             if got != remote_file_hash:
                 raise RuntimeError(
-                    f"Hash mismatch for:\n{outfile}\n"
+                    f"Hash mismatch for:\n{dataset_path}\n"
                     f"Expected:\n{remote_file_hash}\nGot:\n{got}"
                 )
 
@@ -597,7 +602,7 @@ async def _retrieve_and_write_to_disk(
             local_file_size = outfile.stat().st_size
             if remote_file_size is not None and local_file_size != remote_file_size:
                 raise RuntimeError(
-                    f"Server claimed size of {outfile} would be "
+                    f"Size mismatch for {dataset_path}: expected "
                     f"{remote_file_size} bytes, but downloaded "
                     f"{local_file_size} bytes."
                 )
@@ -615,7 +620,7 @@ async def _retrieve_and_write_to_disk(
         else:
             if isinstance(data, dict) and list(data) == ["error"]:
                 raise RuntimeError(
-                    f"Error downloading:\n{outfile}:\n"
+                    f"Error downloading:\n{dataset_path}:\n"
                     f"Got JSON error response contents:\n{data}"
                 )
 
@@ -657,6 +662,7 @@ async def _download_files(
             url=url,
             api_file_size=api_file_size,
             outfile=outfile,
+            dataset_path=file.filename,
             verify_hash=verify_hash,
             verify_size=verify_size,
             max_retries=max_retries,

--- a/src/openneuro/_download.py
+++ b/src/openneuro/_download.py
@@ -515,13 +515,14 @@ async def _attempt_download(
                     else:
                         raise RuntimeError(
                             f"Error {response.status_code} when trying to "
-                            f"download {outfile}. If this is unexpected:\n\n"
+                            f"download {remote_path}. If this is "
+                            "unexpected:\n\n"
                             "1. Navigate to "
                             "https://openneuro.org/crn/graphql\n"
                             "2. Enter and run the operation: "
                             f"`{query_str}`\n"
                             "3. In the Response, try to manually download "
-                            f'the "urls" for "{outfile.name}", which should '
+                            f'the "urls" for "{remote_path}", which should '
                             f"contain {url}\n\n"
                             "If the download fails, open a GitHub issue like "
                             "https://github.com/OpenNeuroOrg/openneuro/"

--- a/src/openneuro/_download.py
+++ b/src/openneuro/_download.py
@@ -322,7 +322,7 @@ async def _download_file(
     url: str,
     api_file_size: int | None,
     outfile: Path,
-    dataset_path: str,
+    remote_path: str,
     verify_hash: bool,
     verify_size: bool,
     max_retries: int,
@@ -338,7 +338,7 @@ async def _download_file(
                 url=url,
                 api_file_size=api_file_size,
                 outfile=outfile,
-                dataset_path=dataset_path,
+                remote_path=remote_path,
                 verify_hash=verify_hash,
                 verify_size=verify_size,
                 semaphore=semaphore,
@@ -355,7 +355,7 @@ async def _download_file(
                 else:
                     reason = str(err) or "Error"
                 _write_retry(
-                    what=f"downloading {dataset_path}",
+                    what=f"downloading {remote_path}",
                     reason=reason,
                     retry=max_retries - attempt,
                     backoff=retry_backoff,
@@ -364,7 +364,7 @@ async def _download_file(
                 retry_backoff *= 2
             else:
                 raise RuntimeError(
-                    f"Failed to download {dataset_path} from {url} "
+                    f"Failed to download {remote_path} from {url} "
                     f"after {max_retries} retries."
                 ) from (err.__cause__ or err)
 
@@ -374,7 +374,7 @@ async def _attempt_download(
     url: str,
     api_file_size: int | None,
     outfile: Path,
-    dataset_path: str,
+    remote_path: str,
     verify_hash: bool,
     verify_size: bool,
     semaphore: asyncio.Semaphore,
@@ -531,7 +531,7 @@ async def _attempt_download(
                     await _retrieve_and_write_to_disk(
                         response=response,
                         outfile=outfile,
-                        dataset_path=dataset_path,
+                        remote_path=remote_path,
                         mode=mode,
                         desc=desc,
                         local_file_size=local_file_size,
@@ -548,7 +548,7 @@ async def _retrieve_and_write_to_disk(
     *,
     response: httpx.Response,
     outfile: Path,
-    dataset_path: str,
+    remote_path: str,
     mode: Literal["ab", "wb"],
     desc: str,
     local_file_size: int,
@@ -592,7 +592,7 @@ async def _retrieve_and_write_to_disk(
             got = hash.hexdigest()
             if got != remote_file_hash:
                 raise RuntimeError(
-                    f"Hash mismatch for:\n{dataset_path}\n"
+                    f"Hash mismatch for:\n{remote_path}\n"
                     f"Expected:\n{remote_file_hash}\nGot:\n{got}"
                 )
 
@@ -602,7 +602,7 @@ async def _retrieve_and_write_to_disk(
             local_file_size = outfile.stat().st_size
             if remote_file_size is not None and local_file_size != remote_file_size:
                 raise RuntimeError(
-                    f"Size mismatch for {dataset_path}: expected "
+                    f"Size mismatch for {remote_path}: expected "
                     f"{remote_file_size} bytes, but downloaded "
                     f"{local_file_size} bytes."
                 )
@@ -620,7 +620,7 @@ async def _retrieve_and_write_to_disk(
         else:
             if isinstance(data, dict) and list(data) == ["error"]:
                 raise RuntimeError(
-                    f"Error downloading:\n{dataset_path}:\n"
+                    f"Error downloading:\n{remote_path}:\n"
                     f"Got JSON error response contents:\n{data}"
                 )
 
@@ -662,7 +662,7 @@ async def _download_files(
             url=url,
             api_file_size=api_file_size,
             outfile=outfile,
-            dataset_path=file.filename,
+            remote_path=file.filename,
             verify_hash=verify_hash,
             verify_size=verify_size,
             max_retries=max_retries,

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -923,10 +923,7 @@ def test_head_non_retryable_status_code(tmp_path: Path):
 # -- _retrieve_and_write_to_disk with remote_file_size=None --
 
 
-def test_retrieve_and_write_to_disk_none_size(tmp_path: Path):
-    """verify_size=True with remote_file_size=None must not crash."""
-    outfile = tmp_path / "test.txt"
-    content = b"hello world"
+def _mock_response(content: bytes) -> AsyncMock:
     response = AsyncMock()
     response.num_bytes_downloaded = len(content)
 
@@ -934,10 +931,17 @@ def test_retrieve_and_write_to_disk_none_size(tmp_path: Path):
         yield content
 
     response.aiter_bytes = aiter_bytes
+    return response
+
+
+def test_retrieve_and_write_to_disk_none_size(tmp_path: Path):
+    """verify_size=True with remote_file_size=None must not crash."""
+    outfile = tmp_path / "test.txt"
+    content = b"hello world"
 
     asyncio.run(
         _retrieve_and_write_to_disk(
-            response=response,
+            response=_mock_response(content),
             outfile=outfile,
             remote_path="test.txt",
             mode="wb",
@@ -950,3 +954,24 @@ def test_retrieve_and_write_to_disk_none_size(tmp_path: Path):
         )
     )
     assert outfile.read_bytes() == content
+
+
+def test_size_mismatch_uses_remote_path(tmp_path: Path):
+    """Error message must contain remote_path, not the local outfile path."""
+    remote_path = "sub-01/meg/file.fif"
+    with pytest.raises(RuntimeError, match=remote_path) as exc_info:
+        asyncio.run(
+            _retrieve_and_write_to_disk(
+                response=_mock_response(b"hello"),
+                outfile=tmp_path / "test.txt",
+                remote_path=remote_path,
+                mode="wb",
+                desc="test",
+                local_file_size=0,
+                remote_file_size=999_999,  # intentional mismatch
+                remote_file_hash=None,
+                verify_hash=False,
+                verify_size=True,
+            )
+        )
+    assert str(tmp_path) not in str(exc_info.value)

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -852,6 +852,7 @@ def _run_download_file(
             url="https://example.com/test.txt",
             api_file_size=5,
             outfile=tmp_path / "test.txt",
+            dataset_path="test.txt",
             verify_hash=False,
             verify_size=False,
             max_retries=3,
@@ -938,6 +939,7 @@ def test_retrieve_and_write_to_disk_none_size(tmp_path: Path):
         _retrieve_and_write_to_disk(
             response=response,
             outfile=outfile,
+            dataset_path="test.txt",
             mode="wb",
             desc="test",
             local_file_size=0,

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -852,7 +852,7 @@ def _run_download_file(
             url="https://example.com/test.txt",
             api_file_size=5,
             outfile=tmp_path / "test.txt",
-            dataset_path="test.txt",
+            remote_path="test.txt",
             verify_hash=False,
             verify_size=False,
             max_retries=3,
@@ -939,7 +939,7 @@ def test_retrieve_and_write_to_disk_none_size(tmp_path: Path):
         _retrieve_and_write_to_disk(
             response=response,
             outfile=outfile,
-            dataset_path="test.txt",
+            remote_path="test.txt",
             mode="wb",
             desc="test",
             local_file_size=0,


### PR DESCRIPTION
Error messages from the download chain previously displayed the full local filesystem path, which was misleading when attributing information to the server.

Thread a `remote_path` parameter through the download functions and use it in all user-facing error messages, so they now show the dataset-relative path instead (e.g., `sub-01/meg/file.fif`).

**Concrete examle:**

I used to see:

> RuntimeError: Server claimed size of /private/tmp/ds003104/sub-01/meg/sub-01_task-somato_meg.fif would be 343683462 bytes, but downloaded 0 bytes.

Now I see:

> RuntimeError: Size mismatch for sub-01/meg/sub-01_task-somato_meg.fif: expected 343683462 bytes, but downloaded 0 bytes.

which I believe makes more sense.