### PR TITLE
Limit to 5 concurrent head requests

### DIFF
--- a/src/openneuro/_download.py
+++ b/src/openneuro/_download.py
@@ -107,7 +107,7 @@ allowed_retry_exceptions = (
 )
 user_agent_header: dict[str, str] = {"user-agent": f"openneuro-py/{__version__}"}
 
-_MAX_CONCURRENT_HEAD_REQUESTS = 50
+_MAX_CONCURRENT_HEAD_REQUESTS = 5
 
 # GraphQL endpoint and queries.
 


### PR DESCRIPTION
Just one possible naive solution for https://github.com/openneuro-py/openneuro-py/issues/342 . It seems to be working in https://github.com/mne-tools/mne-bids-pipeline/pull/1250 in the run here at least.

Comparing download times, the last one that passed [on `main` took](https://app.circleci.com/pipelines/github/mne-tools/mne-bids-pipeline/5667/workflows/fef5dbb0-48da-4bb1-ab1b-5462672bfa8d/jobs/108091) 43s for the download step, and using [this branch it took](https://app.circleci.com/pipelines/gh/mne-tools/mne-bids-pipeline/5671/workflows/713076a3-2a3e-457b-b0f7-befe8cf4a6b6/jobs/108243) 12s. This appears to be because of all the timeout backoffs it hit in the `main` case (not enough to kill it on that run, but is enough for it to fail completely intermittently, as in https://github.com/mne-tools/mne-bids-pipeline/pull/1250).