### PR TITLE
Allow passing multiple `--include` and `--excldue` values

### DIFF
--- a/src/openneuro/_cli.py
+++ b/src/openneuro/_cli.py
@@ -22,7 +22,7 @@ def download_cli(
         typer.Option(help="The directory to download to.", show_default=False),
     ] = None,
     include: Annotated[
-        str | None,
+        list[str] | None,
         typer.Option(
             help="Only include the specified file or directory. "
             "Can be passed multiple times.",
@@ -30,7 +30,7 @@ def download_cli(
         ),
     ] = None,
     exclude: Annotated[
-        str | None,
+        list[str] | None,
         typer.Option(
             help="Exclude the specified file or directory. "
             "Can be passed multiple times.",

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -833,6 +833,7 @@ def test_max_concurrent_downloads_cli_validation():
     )
     assert result.exit_code == 2
 
+
 def test_multiple_include_options_cli():
     """The CLI should honor multiple --include (and --exclude) options."""
     from typer.testing import CliRunner
@@ -858,6 +859,7 @@ def test_multiple_include_options_cli():
     _, kwargs = mock_download.call_args
     assert kwargs["include"] == ["sub-0001", "sub-0002"]
     assert kwargs["exclude"] == ["*.fif", "*.json"]
+
 
 def _run_download_file(
     tmp_path: Path,

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -833,6 +833,31 @@ def test_max_concurrent_downloads_cli_validation():
     )
     assert result.exit_code == 2
 
+def test_multiple_include_options_cli():
+    """The CLI should honor multiple --include (and --exclude) options."""
+    from typer.testing import CliRunner
+
+    from openneuro._cli import app
+
+    runner = CliRunner()
+    with patch("openneuro._cli.download") as mock_download:
+        result = runner.invoke(
+            app,
+            [
+                "download",
+                "--dataset=ds000117",
+                "--include=sub-0001",
+                "--include=sub-0002",
+                "--exclude=*.fif",
+                "--exclude=*.json",
+            ],
+        )
+
+    assert result.exit_code == 0
+    mock_download.assert_called_once()
+    _, kwargs = mock_download.call_args
+    assert kwargs["include"] == ["sub-0001", "sub-0002"]
+    assert kwargs["exclude"] == ["*.fif", "*.json"]
 
 def _run_download_file(
     tmp_path: Path,


### PR DESCRIPTION
We ran into the multiple includes and excludes issue in our internal projects. It's a small fix, but we are already implementing it for ourselves. Closes #311.