### PR TITLE
Share a single AsyncClient across download tasks (fixes #317)

### DIFF
--- a/src/openneuro/_download.py
+++ b/src/openneuro/_download.py
@@ -344,6 +344,7 @@ def _retry_request(
 
 async def _download_file(
     *,
+    client: httpx.AsyncClient,
     url: str,
     remote_file_size: int | None,
     outfile: Path,
@@ -361,6 +362,7 @@ async def _download_file(
     for attempt in range(max_retries + 1):
         try:
             await _attempt_download(
+                client=client,
                 url=url,
                 remote_file_size=remote_file_size,
                 outfile=outfile,
@@ -402,6 +404,7 @@ async def _download_file(
 
 async def _attempt_download(
     *,
+    client: httpx.AsyncClient,
     url: str,
     remote_file_size: int | None,
     outfile: Path,
@@ -428,140 +431,143 @@ async def _attempt_download(
     #     raise RuntimeError(query_str)
 
     # The OpenNeuro servers are sometimes very slow to respond, so use a
-    # gigantic timeout for those.
+    # gigantic timeout for those. The pool timeout is disabled: tasks may
+    # legitimately wait a long time for a connection from the shared client's
+    # pool, and the semaphores are the sole concurrency throttle.
     if url.startswith("https://openneuro.org/crn/"):
-        timeout = 60
+        timeout = httpx.Timeout(60, pool=None)
     else:
-        timeout = 5
+        timeout = httpx.Timeout(5, pool=None)
 
-    async with httpx.AsyncClient(timeout=timeout, verify=ssl_context) as client:
-        # Phase 1: HEAD request to get remote file hash.
-        try:
-            async with head_semaphore:
-                response = await client.head(url, headers=user_agent_header)
-                if response.status_code in allowed_retry_codes:
+    # Phase 1: HEAD request to get remote file hash.
+    try:
+        async with head_semaphore:
+            response = await client.head(
+                url, headers=user_agent_header, timeout=timeout
+            )
+            if response.status_code in allowed_retry_codes:
+                raise _RetryableError(f"HTTP {response.status_code}")
+            if response.is_error:
+                hint = _download_debug_hint(
+                    remote_path=remote_path,
+                    url=url,
+                    query_str=query_str,
+                )
+                raise RuntimeError(
+                    f"HEAD request failed with HTTP "
+                    f"{response.status_code} for "
+                    f"{remote_path} (url: {url}). {hint}"
+                )
+            headers = response.headers
+    except allowed_retry_exceptions as exc:
+        raise _RetryableError from exc
+
+    # Try to get the S3 MD5 hash for the file.
+    etag = headers.get("etag")
+    etag_hash = etag.strip('"') if etag is not None else None
+    remote_file_hash = (
+        etag_hash if (etag_hash is not None and len(etag_hash) == 32) else None
+    )
+
+    # Phase 2: Local file check (no semaphore held — allows other tasks
+    # to use network slots while we do local I/O).
+    request_headers: dict[str, str] = user_agent_header.copy()
+    request_headers["Accept-Encoding"] = ""  # Disable compression
+
+    mode: Literal["ab", "wb"] = "wb"
+    if (
+        outfile.exists()
+        and remote_file_size is not None
+        and local_file_size == remote_file_size
+    ):
+        hash_ = hashlib.md5()
+
+        if verify_hash and remote_file_hash is not None:
+            async with aiofiles.open(outfile, "rb") as f:
+                while True:
+                    data = await f.read(65536)
+                    if not data:
+                        break
+                    hash_.update(data)
+
+        if (
+            verify_hash
+            and remote_file_hash is not None
+            and hash_.hexdigest() != remote_file_hash
+        ):
+            desc = f"Re-downloading {outfile.name}: file hash mismatch."
+            outfile.unlink()
+            local_file_size = 0
+        else:
+            # Download complete, skip.
+            if not is_retry:
+                overall_progress.update(remote_file_size or 0)
+            return
+    elif (
+        outfile.exists()
+        and remote_file_size is not None
+        and local_file_size < remote_file_size
+    ):
+        # Download incomplete, resume.
+        desc = f"Resuming {outfile.name}"
+        request_headers["Range"] = f"bytes={local_file_size}-"
+        mode = "ab"
+        if not is_retry:
+            overall_progress.update(local_file_size)
+    elif (
+        outfile.exists()
+        and remote_file_size is not None
+        and local_file_size > remote_file_size
+    ):
+        # Local file is larger than remote – overwrite.
+        desc = f"Re-downloading {outfile.name}: file size mismatch."
+        outfile.unlink()
+        local_file_size = 0
+    elif outfile.exists():
+        # Remote size unknown – re-download to be safe.
+        desc = f"Re-downloading {outfile.name}: remote file size unknown."
+        outfile.unlink()
+        local_file_size = 0
+    else:
+        # File doesn't exist locally, download entirely.
+        desc = outfile.name
+
+    # Phase 3: GET request to download the file (re-acquires semaphore).
+    try:
+        async with semaphore:
+            async with client.stream(
+                "GET", url=url, headers=request_headers, timeout=timeout
+            ) as response:
+                if not response.is_error:
+                    pass  # All good!
+                elif response.status_code in allowed_retry_codes:
                     raise _RetryableError(f"HTTP {response.status_code}")
-                if response.is_error:
+                else:
                     hint = _download_debug_hint(
                         remote_path=remote_path,
                         url=url,
                         query_str=query_str,
                     )
                     raise RuntimeError(
-                        f"HEAD request failed with HTTP "
-                        f"{response.status_code} for "
-                        f"{remote_path} (url: {url}). {hint}"
+                        f"Error {response.status_code} when trying to "
+                        f"download {remote_path}. {hint}"
                     )
-                headers = response.headers
-        except allowed_retry_exceptions as exc:
-            raise _RetryableError from exc
 
-        # Try to get the S3 MD5 hash for the file.
-        etag = headers.get("etag")
-        etag_hash = etag.strip('"') if etag is not None else None
-        remote_file_hash = (
-            etag_hash if (etag_hash is not None and len(etag_hash) == 32) else None
-        )
-
-        # Phase 2: Local file check (no semaphore held — allows other tasks
-        # to use network slots while we do local I/O).
-        request_headers: dict[str, str] = user_agent_header.copy()
-        request_headers["Accept-Encoding"] = ""  # Disable compression
-
-        mode: Literal["ab", "wb"] = "wb"
-        if (
-            outfile.exists()
-            and remote_file_size is not None
-            and local_file_size == remote_file_size
-        ):
-            hash_ = hashlib.md5()
-
-            if verify_hash and remote_file_hash is not None:
-                async with aiofiles.open(outfile, "rb") as f:
-                    while True:
-                        data = await f.read(65536)
-                        if not data:
-                            break
-                        hash_.update(data)
-
-            if (
-                verify_hash
-                and remote_file_hash is not None
-                and hash_.hexdigest() != remote_file_hash
-            ):
-                desc = f"Re-downloading {outfile.name}: file hash mismatch."
-                outfile.unlink()
-                local_file_size = 0
-            else:
-                # Download complete, skip.
-                if not is_retry:
-                    overall_progress.update(remote_file_size or 0)
-                return
-        elif (
-            outfile.exists()
-            and remote_file_size is not None
-            and local_file_size < remote_file_size
-        ):
-            # Download incomplete, resume.
-            desc = f"Resuming {outfile.name}"
-            request_headers["Range"] = f"bytes={local_file_size}-"
-            mode = "ab"
-            if not is_retry:
-                overall_progress.update(local_file_size)
-        elif (
-            outfile.exists()
-            and remote_file_size is not None
-            and local_file_size > remote_file_size
-        ):
-            # Local file is larger than remote – overwrite.
-            desc = f"Re-downloading {outfile.name}: file size mismatch."
-            outfile.unlink()
-            local_file_size = 0
-        elif outfile.exists():
-            # Remote size unknown – re-download to be safe.
-            desc = f"Re-downloading {outfile.name}: remote file size unknown."
-            outfile.unlink()
-            local_file_size = 0
-        else:
-            # File doesn't exist locally, download entirely.
-            desc = outfile.name
-
-        # Phase 3: GET request to download the file (re-acquires semaphore).
-        try:
-            async with semaphore:
-                async with client.stream(
-                    "GET", url=url, headers=request_headers
-                ) as response:
-                    if not response.is_error:
-                        pass  # All good!
-                    elif response.status_code in allowed_retry_codes:
-                        raise _RetryableError(f"HTTP {response.status_code}")
-                    else:
-                        hint = _download_debug_hint(
-                            remote_path=remote_path,
-                            url=url,
-                            query_str=query_str,
-                        )
-                        raise RuntimeError(
-                            f"Error {response.status_code} when trying to "
-                            f"download {remote_path}. {hint}"
-                        )
-
-                    await _retrieve_and_write_to_disk(
-                        response=response,
-                        outfile=outfile,
-                        remote_path=remote_path,
-                        mode=mode,
-                        desc=desc,
-                        local_file_size=local_file_size,
-                        remote_file_size=remote_file_size,
-                        remote_file_hash=remote_file_hash,
-                        verify_hash=verify_hash,
-                        verify_size=verify_size,
-                        overall_progress=overall_progress,
-                    )
-        except allowed_retry_exceptions as exc:
-            raise _RetryableError from exc
+                await _retrieve_and_write_to_disk(
+                    response=response,
+                    outfile=outfile,
+                    remote_path=remote_path,
+                    mode=mode,
+                    desc=desc,
+                    local_file_size=local_file_size,
+                    remote_file_size=remote_file_size,
+                    remote_file_hash=remote_file_hash,
+                    verify_hash=verify_hash,
+                    verify_size=verify_size,
+                    overall_progress=overall_progress,
+                )
+    except allowed_retry_exceptions as exc:
+        raise _RetryableError from exc
 
 
 async def _retrieve_and_write_to_disk(
@@ -692,34 +698,44 @@ async def _download_files(
         )
 
     total_bytes = sum(fi.size or 0 for fi in file_infos)
-    with tqdm(
-        total=total_bytes,
-        desc="Overall",
-        unit="B",
-        unit_scale=True,
-        unit_divisor=1024,
-        miniters=1,
-        leave=True,
-    ) as overall_progress:
-        download_tasks = [
-            _download_file(
-                url=fi.url,
-                remote_file_size=fi.size,
-                outfile=fi.outfile,
-                remote_path=fi.remote_path,
-                verify_hash=verify_hash,
-                verify_size=verify_size,
-                max_retries=max_retries,
-                retry_backoff=retry_backoff,
-                semaphore=semaphore,
-                head_semaphore=head_semaphore,
-                query_str=normalized_query_str,
-                overall_progress=overall_progress,
-            )
-            for fi in file_infos
-        ]
-        del file_infos
-        await asyncio.gather(*download_tasks)
+    # A single client shared by all download tasks, so open connections are
+    # bounded by the pool size instead of the file count. The pool is sized
+    # to never throttle below the semaphores: it bounds socket usage, while
+    # the semaphores remain the sole queuing mechanism.
+    limits = httpx.Limits(
+        max_connections=max_concurrent_downloads + _MAX_CONCURRENT_HEAD_REQUESTS,
+        max_keepalive_connections=max_concurrent_downloads,
+    )
+    async with httpx.AsyncClient(verify=ssl_context, limits=limits) as client:
+        with tqdm(
+            total=total_bytes,
+            desc="Overall",
+            unit="B",
+            unit_scale=True,
+            unit_divisor=1024,
+            miniters=1,
+            leave=True,
+        ) as overall_progress:
+            download_tasks = [
+                _download_file(
+                    client=client,
+                    url=fi.url,
+                    remote_file_size=fi.size,
+                    outfile=fi.outfile,
+                    remote_path=fi.remote_path,
+                    verify_hash=verify_hash,
+                    verify_size=verify_size,
+                    max_retries=max_retries,
+                    retry_backoff=retry_backoff,
+                    semaphore=semaphore,
+                    head_semaphore=head_semaphore,
+                    query_str=normalized_query_str,
+                    overall_progress=overall_progress,
+                )
+                for fi in file_infos
+            ]
+            del file_infos
+            await asyncio.gather(*download_tasks)
 
 
 def _get_local_tag(*, dataset_id: str, dataset_dir: Path) -> str | None:

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -21,7 +21,7 @@ from openneuro._download import (
     _retrieve_and_write_to_disk,
     download,
 )
-from openneuro._models import Snapshot
+from openneuro._models import DatasetFile, Snapshot
 from tests.utils import load_json
 
 dataset_id_aws = "ds000246"
@@ -772,7 +772,7 @@ def _make_fake_client(
     """
     head_call_count = 0
 
-    async def head(url, *, headers=None):
+    async def head(url, *, headers=None, timeout=None):
         nonlocal head_call_count
         head_call_count += 1
         if head_call_count <= fail_head_n_times:
@@ -808,9 +808,7 @@ def _make_fake_client(
 
     client = AsyncMock()
     client.head = head
-    client.stream = lambda method, *, url, headers=None: _FakeStream()
-    client.__aenter__ = AsyncMock(return_value=client)
-    client.__aexit__ = AsyncMock(return_value=False)
+    client.stream = lambda method, *, url, headers=None, timeout=None: _FakeStream()
     return client
 
 
@@ -877,6 +875,7 @@ def _run_download_file(
     async def run():
         with tqdm(total=5, disable=True) as overall_progress:
             await _download_file(
+                client=mock_client,
                 url="https://example.com/test.txt",
                 remote_file_size=5,
                 outfile=tmp_path / "test.txt",
@@ -891,8 +890,7 @@ def _run_download_file(
                 overall_progress=overall_progress,
             )
 
-    with patch("openneuro._download.httpx.AsyncClient", return_value=mock_client):
-        asyncio.run(run())
+    asyncio.run(run())
 
 
 def test_semaphore_not_leaked_on_retry(tmp_path: Path):
@@ -985,6 +983,86 @@ def test_retrieve_and_write_to_disk_none_size(tmp_path: Path):
             )
         )
     assert outfile.read_bytes() == content
+
+
+# -- shared-client connection bounding (gh-317) --
+
+
+async def _serve_counting_http(
+    reader: asyncio.StreamReader,
+    writer: asyncio.StreamWriter,
+    conn_stats: dict[str, int],
+    body: bytes,
+) -> None:
+    """Minimal keep-alive HTTP/1.1 handler that tracks open connections."""
+    conn_stats["open"] += 1
+    conn_stats["peak"] = max(conn_stats["peak"], conn_stats["open"])
+    try:
+        while True:
+            request = await reader.readuntil(b"\r\n\r\n")
+            method = request.split(b" ", 1)[0].decode()
+            writer.write(b"HTTP/1.1 200 OK\r\nContent-Length: %d\r\n\r\n" % len(body))
+            if method == "GET":
+                writer.write(body)
+            await writer.drain()
+    except (asyncio.IncompleteReadError, ConnectionResetError):
+        pass  # Client closed the connection.
+    finally:
+        conn_stats["open"] -= 1
+        writer.close()
+
+
+def test_connections_bounded_by_pool_not_file_count(tmp_path: Path):
+    """Open connections must stay bounded by the pool size, not the file count.
+
+    Regression test for gh-317: a per-file ``httpx.AsyncClient`` meant every
+    dispatched task held an open connection while waiting for a download
+    slot, so connection count grew with the number of files in the dataset.
+    """
+    max_concurrent_downloads = 3
+    connection_bound = (
+        max_concurrent_downloads + _download._MAX_CONCURRENT_HEAD_REQUESTS
+    )
+    n_files = 3 * connection_bound  # Enough that per-file clients would exceed it.
+    body = b"0123456789"
+    conn_stats = {"open": 0, "peak": 0}
+
+    async def run() -> None:
+        server = await asyncio.start_server(
+            lambda r, w: _serve_counting_http(r, w, conn_stats, body),
+            "127.0.0.1",
+            0,
+        )
+        port = server.sockets[0].getsockname()[1]
+        files = [
+            DatasetFile(
+                filename=f"file_{i}.txt",
+                urls=[f"http://127.0.0.1:{port}/file_{i}.txt"],
+                size=len(body),
+                id=f"id_{i}",
+            )
+            for i in range(n_files)
+        ]
+        async with server:
+            await _download._download_files(
+                target_dir=tmp_path,
+                files=files,
+                verify_hash=False,
+                verify_size=True,
+                max_retries=0,
+                retry_backoff=0.0,
+                max_concurrent_downloads=max_concurrent_downloads,
+                query_str="test",
+            )
+
+    asyncio.run(run())
+
+    assert conn_stats["peak"] <= connection_bound, (
+        f"Peak connections ({conn_stats['peak']}) exceeded the pool bound "
+        f"({connection_bound}) for {n_files} files"
+    )
+    for i in range(n_files):
+        assert (tmp_path / f"file_{i}.txt").read_bytes() == body
 
 
 def test_size_mismatch_uses_remote_path(tmp_path: Path):


### PR DESCRIPTION
> [!NOTE]
> Best reviewed with whitespace hidden (append `?w=1` to the "Files changed" URL, or use the gear icon): removing the per-file `async with httpx.AsyncClient(...)` block re-indented ~130 lines. The semantic change is ~30 lines in `_download.py` (`git diff -w`).

## Problem

`_attempt_download()` created a fresh `httpx.AsyncClient` per file, *outside* the download semaphore. Since all file tasks are created up front, every dispatched task held an open client/connection while waiting for a GET slot — so open connections grew with file count, not with `max_concurrent_downloads`.

Empirically confirmed on `ds007523` (~446 GB, 2504 files, `max_concurrent_downloads=5`): established TCP connections climbed past 2,300 with `timewait` near zero, throughput collapsed to ~KB/s, trending toward ephemeral-port exhaustion. Details in #317. This likely also underlies the retry storm in #342 (each retry wave multiplied client count), which #344 only papered over.

Closes #317
Closes #342 
Closes #344

## Fix

One shared `AsyncClient` created in `_download_files()`, threaded explicitly through `_download_file()` → `_attempt_download()` (same pattern as the existing semaphores). Downstream code borrows the client and never closes it.

- **Pool sizing:** the pool is a backstop, not a throttle — sized so it never binds below the semaphores:

  ```python
  limits = httpx.Limits(
      max_connections=max_concurrent_downloads + _MAX_CONCURRENT_HEAD_REQUESTS,
      max_keepalive_connections=max_concurrent_downloads,
  )
  ```

- **Timeouts:** the per-URL timeout (60 s for `openneuro.org/crn/`, 5 s otherwise) moves from the client constructor to per-request arguments. The pool timeout is explicitly disabled (`httpx.Timeout(60, pool=None)`) because tasks now legitimately wait for a connection from the shared pool; the semaphores remain the sole queuing mechanism, avoiding spurious `PoolTimeout`s.

As a side benefit, keep-alive connections are now reused across files, which removes per-file TCP/TLS handshake overhead — noticeable on BIDS datasets with many small sidecar files.

## Not done here (deliberately)

Bounding task creation with a worker pool would also fix this, but it's a larger refactor of the retry/progress logic and forfeits cross-file connection reuse. Per the discussion in #317, this fixes the resource lifetime now and punts on the #293 client-library question.

## Regression test

`test_connections_bounded_by_pool_not_file_count`: downloads 159 tiny files through an in-process connection-counting HTTP server and asserts peak concurrent connections ≤ pool bound (53), plus file integrity. Verified the test discriminates: with the old per-file-client behavior, peak connections equal the file count exactly (24/24 in a scaled-down run) and the full-size run wedges itself holding 318 open sockets.

## Empirical A/B verification (Google Colab)

Same command on both branches — `openneuro-py download --dataset=ds007523 --max-concurrent-downloads=5` — sampling the download process's file descriptors and system-wide established `:443` connections every 20 s:

**`main` (per-file clients):**

```
 t(s)   fds  established
    0     4            1
   20   411          111
   40   600           93
   60   738           84
   80   875           87
  100   948           55
```

**This branch (shared client):**

```
 t(s)   fds  established
    0    96           50
   20    32           18
   40    59           47
   60    40           28
   80    72           60
  100    67           55
```

On `main`, fds climb monotonically (~150 per 20 s, on track for the dataset's 2,504 files); on this branch they oscillate in the 32–96 range, bounded by the pool. Note the `established` count on `main` looks deceptively flat: on Colab the servers close idle keep-alive connections, and since the leaked per-file clients never close their end, the sockets accumulate in CLOSE_WAIT — no longer ESTABLISHED, but still pinning an fd each. The environment-invariant symptom of this bug is the per-process fd count, which is why the regression test counts connections at the server rather than grepping socket states.
