### PR TITLE
Add support for NEMAR downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,11 +124,51 @@ openneuro-py login
 
 Paste the API key and press return.
 
+### Download from the NEMAR mirror
+
+[NEMAR](https://nemar.org) is a partner archive at UC San Diego that mirrors
+the EEG, MEG, and iEEG datasets published on OpenNeuro. The files are
+byte-for-byte identical, and NEMAR publishes a checksum for every file, which
+`openneuro-py` verifies as it downloads.
+
+```shell
+openneuro-py download --dataset=ds004840 --source=nemar
+```
+
+To make it the default for every command, set the `OPENNEURO_SOURCE`
+environment variable:
+
+```shell
+export OPENNEURO_SOURCE=nemar
+```
+
+A few things work differently when downloading from NEMAR:
+
+- **Only MEEG datasets are mirrored.** Anything else — and anything NEMAR has
+  not mirrored yet — is unavailable, and `openneuro-py` will tell you to use
+  `--source=openneuro` instead.
+- **`--tag` always means the OpenNeuro revision**, never NEMAR's own version
+  number (the two do not correspond). NEMAR keeps only the single snapshot it
+  most recently mirrored, so requesting any other revision fails with a message
+  naming the one it does have.
+- **Restricted datasets are not available**, since NEMAR serves only public
+  data and does not use your OpenNeuro API token.
+- **A couple of metadata files differ.** NEMAR points `DatasetDOI` at its own
+  identifier (recording the OpenNeuro one under `SourceDatasets`), adds a
+  `.bidsignore`, and stores the README as `README.md`. The data files
+  themselves are unchanged.
+
 ## Basic usage – Python interface
 
 ```python
 import openneuro as on
 on.download(dataset='ds000246', target_dir='data/bids')
+```
+
+To download from the NEMAR mirror instead, pass `source`:
+
+```python
+on.download(dataset='ds004840', target_dir='data/bids', source='nemar')
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -184,6 +184,21 @@ A few things work differently when downloading from NEMAR:
   `.bidsignore`, and stores the README as `README.md`. The data files
   themselves are unchanged.
 
+### See also: `nemar-py`
+
+The NEMAR team maintains [`nemar-py`](https://github.com/nemarOrg/nemar-py), a
+dedicated client for `data.nemar.org`. If NEMAR is your primary archive rather
+than a mirror of OpenNeuro, it is the better tool: it addresses datasets by
+NEMAR ID (`nm…`/`on…`) and NEMAR version, so it can reach NEMAR-native datasets
+that were never on OpenNeuro, and older NEMAR releases that `openneuro-py` does
+not expose. It also offers BIDS-entity filters (`--subject`, `--task`,
+`--datatype`, …) and optional DataLad/git-annex and S3 backends.
+
+`--source=nemar` here is for the other direction: staying in OpenNeuro's
+namespace — OpenNeuro dataset IDs and OpenNeuro revisions, with the `include`
+and `exclude` patterns you already use — while the bytes happen to come from
+NEMAR.
+
 ## Basic usage – Python interface
 
 ```python

--- a/README.md
+++ b/README.md
@@ -142,6 +142,32 @@ environment variable:
 export OPENNEURO_SOURCE=nemar
 ```
 
+### Stronger integrity checking for OpenNeuro downloads
+
+OpenNeuro publishes no checksums, so `openneuro-py` falls back to the S3
+`ETag`. That is an MD5 only for single-part uploads: files of 1 GiB or more are
+uploaded in parts and return a digest-of-digests, which cannot be checked at
+all. An `ETag` also only describes what OpenNeuro has *stored*, so it cannot
+reveal a file that was already corrupt at rest.
+
+Because NEMAR mirrors OpenNeuro byte-for-byte and publishes a checksum for
+every file, it can close both gaps. By default (`verify_hash="auto"`)
+`openneuro-py` consults NEMAR only when the files being downloaded include one
+past that threshold — most downloads never contact it:
+
+```shell
+# Always cross-check against NEMAR, whatever the file sizes:
+openneuro-py download --dataset=ds000246 --nemar-checksums
+
+# Never contact NEMAR; use only OpenNeuro's own ETags:
+openneuro-py download --dataset=ds000246 --no-nemar-checksums
+```
+
+If NEMAR is unreachable, or mirrors a different revision than the one being
+downloaded, this degrades to the `ETag` behaviour rather than failing.
+
+### Differences when downloading from NEMAR
+
 A few things work differently when downloading from NEMAR:
 
 - **Only MEEG datasets are mirrored.** Anything else — and anything NEMAR has

--- a/src/openneuro/_cli.py
+++ b/src/openneuro/_cli.py
@@ -1,4 +1,4 @@
-from typing import Annotated
+from typing import Annotated, Literal
 
 import typer
 
@@ -45,15 +45,17 @@ def download_cli(
         ),
     ] = True,
     nemar_checksums: Annotated[
-        bool,
+        bool | None,
         typer.Option(
-            "--nemar-checksums",
+            "--nemar-checksums/--no-nemar-checksums",
             help="Verify an OpenNeuro download against NEMAR's checksums. "
-            "OpenNeuro publishes none of its own, so large (multipart-uploaded) "
-            "files are otherwise left unverified. Ignored when --source=nemar, "
-            "which always ships checksums.",
+            "OpenNeuro publishes none of its own, so files of 1 GiB or more "
+            "(uploaded to S3 in parts) cannot be checked at all. By default "
+            "NEMAR is consulted only when such a file is being downloaded; "
+            "--nemar-checksums always consults it, --no-nemar-checksums never "
+            "does. Ignored when --source=nemar, which always ships checksums.",
         ),
-    ] = False,
+    ] = None,
     verify_size: Annotated[
         bool,
         typer.Option(help="Whether to check the size of each downloaded file."),
@@ -95,13 +97,24 @@ def download_cli(
             "--nemar-checksums cannot be combined with --no-verify-hash: the "
             "first asks for stricter verification, the second for none."
         )
+    # --no-verify-hash means no hashing at all; otherwise --nemar-checksums
+    # decides how hard we look: unset consults NEMAR only when it can help.
+    verify: bool | Literal["auto", "nemar"]
+    if not verify_hash:
+        verify = False
+    elif nemar_checksums is None:
+        verify = "auto"
+    elif nemar_checksums:
+        verify = "nemar"
+    else:
+        verify = True
     download(
         dataset=dataset,
         tag=tag,
         target_dir=target_dir,
         include=include,
         exclude=exclude,
-        verify_hash="nemar" if nemar_checksums else verify_hash,
+        verify_hash=verify,
         verify_size=verify_size,
         max_retries=max_retries,
         max_concurrent_downloads=max_concurrent_downloads,

--- a/src/openneuro/_cli.py
+++ b/src/openneuro/_cli.py
@@ -3,6 +3,7 @@ from typing import Annotated
 import typer
 
 import openneuro
+from openneuro._config import Source
 from openneuro._download import download, login
 
 app = typer.Typer(no_args_is_help=True, pretty_exceptions_show_locals=False)
@@ -40,9 +41,19 @@ def download_cli(
     verify_hash: Annotated[
         bool,
         typer.Option(
-            help="Whether to check the SHA256 hash of each downloaded file.",
+            help="Whether to check the hash of each downloaded file.",
         ),
     ] = True,
+    nemar_checksums: Annotated[
+        bool,
+        typer.Option(
+            "--nemar-checksums",
+            help="Verify an OpenNeuro download against NEMAR's checksums. "
+            "OpenNeuro publishes none of its own, so large (multipart-uploaded) "
+            "files are otherwise left unverified. Ignored when --source=nemar, "
+            "which always ships checksums.",
+        ),
+    ] = False,
     verify_size: Annotated[
         bool,
         typer.Option(help="Whether to check the size of each downloaded file."),
@@ -66,19 +77,36 @@ def download_cli(
             help="Timeout in seconds for metadata queries.",
         ),
     ] = 15.0,
+    source: Annotated[
+        Source | None,
+        typer.Option(
+            help="Where to fetch the data from: OpenNeuro itself, or the NEMAR "
+            "mirror (https://nemar.org), which carries the EEG, MEG, and iEEG "
+            "datasets published on OpenNeuro. --tag always refers to an "
+            "OpenNeuro revision either way. Defaults to the OPENNEURO_SOURCE "
+            "environment variable, or 'openneuro'.",
+            show_default=False,
+        ),
+    ] = None,
 ) -> None:
     """Download datasets from OpenNeuro."""
+    if nemar_checksums and not verify_hash:
+        raise typer.BadParameter(
+            "--nemar-checksums cannot be combined with --no-verify-hash: the "
+            "first asks for stricter verification, the second for none."
+        )
     download(
         dataset=dataset,
         tag=tag,
         target_dir=target_dir,
         include=include,
         exclude=exclude,
-        verify_hash=verify_hash,
+        verify_hash="nemar" if nemar_checksums else verify_hash,
         verify_size=verify_size,
         max_retries=max_retries,
         max_concurrent_downloads=max_concurrent_downloads,
         metadata_timeout=metadata_timeout,
+        source=source,
     )
 
 

--- a/src/openneuro/_config.py
+++ b/src/openneuro/_config.py
@@ -3,7 +3,7 @@ import json
 import os
 import stat
 from pathlib import Path
-from typing import TypedDict
+from typing import Literal, TypedDict, get_args
 
 import platformdirs
 
@@ -15,6 +15,51 @@ CONFIG_DIR = Path(
 CONFIG_DIR.mkdir(parents=True, exist_ok=True)
 CONFIG_PATH = CONFIG_DIR / "config.json"
 BASE_URL = "https://openneuro.org/"
+
+#: Where to fetch dataset files from. See `openneuro.download`.
+Source = Literal["openneuro", "nemar"]
+SOURCES: tuple[Source, ...] = get_args(Source)
+DEFAULT_SOURCE: Source = "openneuro"
+#: Environment variable that supplies the default when `source` is not passed.
+SOURCE_ENV_VAR = "OPENNEURO_SOURCE"
+
+
+def get_source(source: Source | None = None) -> Source:
+    """Resolve which source to download from.
+
+    An explicit `source` argument wins; otherwise the `OPENNEURO_SOURCE`
+    environment variable is consulted, falling back to `"openneuro"`.
+
+    Parameters
+    ----------
+    source
+        The explicitly requested source, or `None` to consult the environment.
+
+    Returns
+    -------
+    The resolved source name.
+
+    Raises
+    ------
+    ValueError
+        When `source` (or the environment variable) is not a known source.
+
+    """
+    if source is None:
+        candidate = os.getenv(SOURCE_ENV_VAR, "").strip()
+        if not candidate:
+            return DEFAULT_SOURCE
+        origin = f"The {SOURCE_ENV_VAR} environment variable"
+    else:
+        candidate = source
+        origin = "The requested source"
+
+    for known in SOURCES:
+        if candidate == known:
+            return known
+    raise ValueError(
+        f"{origin} must be one of {', '.join(SOURCES)}, but got: {candidate!r}"
+    )
 
 
 class Config(TypedDict):

--- a/src/openneuro/_console.py
+++ b/src/openneuro/_console.py
@@ -3,7 +3,15 @@
 A single, module-level `Console` is shared by the progress bars and the plain
 status messages so the two coordinate: messages printed with `cprint` are
 rendered *above* any live progress display instead of clobbering it.
+
+The message-formatting helpers live here too (rather than in `_download`) so
+that every module which talks to a remote host — `_download` and `_nemar`
+alike — can report progress and retries identically without importing one
+another.
 """
+
+import io
+import sys
 
 from rich.console import Console
 
@@ -33,3 +41,43 @@ def cprint(msg: str = "") -> None:
         print(msg, flush=True)
     else:
         console.print(msg, markup=False, highlight=False)
+
+
+def _probe_unicode() -> bool:
+    """Whether the stream the console writes to can encode emoji.
+
+    Jupyter takes the `print()` path in `cprint`, but there both streams are
+    UTF-8 `OutStream`s, so probing stderr answers for it too. `encoding` is
+    typed loosely because it is `None` on a redirected stream such as
+    `io.StringIO` (`contextlib.redirect_stderr`), which must not raise here:
+    this runs at import time.
+    """
+    encoding = getattr(sys.stderr, "encoding", None)
+    if isinstance(encoding, str) and encoding.lower() == "utf-8":
+        return True
+    if isinstance(sys.stderr, io.TextIOWrapper):
+        sys.stderr.reconfigure(encoding="utf-8")
+        return True
+    return False
+
+
+unicode_ok = _probe_unicode()
+
+
+def _unicode(msg: str, *, emoji: str = " ", end: str = "…") -> str:
+    if unicode_ok:
+        msg = f"{emoji} {msg} {end}"
+    elif end == "…":
+        msg = f"{msg} ..."
+    return msg
+
+
+def _write_retry(*, what: str, reason: str, retry: int, backoff: float) -> None:
+    remaining = "1 retry remains" if retry == 1 else f"{retry} retries remain"
+    remaining += f", backing off {backoff:0.1f}s"
+    cprint(
+        _unicode(
+            f"{reason} while {what}, retrying ({remaining})",
+            emoji="🔄",
+        )
+    )

--- a/src/openneuro/_download.py
+++ b/src/openneuro/_download.py
@@ -199,14 +199,30 @@ _debug_hint_template = string.Template(
     "https://github.com/OpenNeuroOrg/openneuro/issues/3145"
 )
 
-_nemar_debug_hint = (
-    "If this is unexpected:\n\n"
-    f"1. Navigate to {_nemar.NEMAR_DATA_URL}/<dataset>/<version>/manifest.json\n"
-    '2. Try to manually download the "bytes_url" for the failing files '
-    "listed above.\n\n"
-    'You can also pass source="openneuro" to download the same data from '
-    "OpenNeuro instead."
-)
+
+def _make_nemar_debug_hint(dataset_id: str) -> str:
+    """Build the dataset-level debug hint for a NEMAR download.
+
+    The URL is spelled out rather than left as placeholders: NEMAR addresses
+    this dataset by its own ID (`on…`, not the `ds…` the caller passed) and by
+    its own version numbering (not the OpenNeuro tag), so a hint the reader has
+    to fill in themselves would send them to a 404. Pointing at the dataset
+    landing page also sidesteps the version entirely — it lists every version
+    together with its `manifest_url`.
+    """
+    nemar_id = _nemar.to_nemar_id(dataset_id)
+    return (
+        "If this is unexpected:\n\n"
+        f"1. Navigate to {_nemar.NEMAR_DATA_URL}/{nemar_id}/ — NEMAR mirrors "
+        f"{dataset_id} as {nemar_id}, and this lists each version it holds "
+        'along with a "manifest_url" (relative to '
+        f"{_nemar.NEMAR_DATA_URL}).\n"
+        '2. Open that manifest and try to manually download the "bytes_url" '
+        "for the failing files listed above.\n\n"
+        'You can also pass source="openneuro" to download the same data from '
+        "OpenNeuro instead."
+    )
+
 
 # `DatasetDOI` as written by OpenNeuro, e.g. "10.18112/openneuro.ds000117.v1.1.0",
 # and as rewritten by NEMAR, e.g. "10.82901/nemar.on000117" (optionally carrying
@@ -1502,7 +1518,7 @@ def download(
         max_concurrent_downloads=max_concurrent_downloads,
         query_str=query_str,
         stats=stats,
-        debug_hint=_nemar_debug_hint if source == "nemar" else None,
+        debug_hint=_make_nemar_debug_hint(dataset) if source == "nemar" else None,
     )
 
     # Block until the download actually finishes, even when a loop is already

--- a/src/openneuro/_download.py
+++ b/src/openneuro/_download.py
@@ -217,6 +217,21 @@ _OPENNEURO_DOI_RE = re.compile(
 )
 _NEMAR_DOI_RE = re.compile(r"^10\.82901/nemar\.on(?P<number>\d+)(?:\.v.+)?$")
 
+#: Size at or above which an OpenNeuro file is likely to have been uploaded to
+#: S3 in multiple parts, making its `ETag` a digest-of-digests rather than an
+#: MD5 of the contents — and so useless for verification.
+#:
+#: This is only a *trigger* for asking NEMAR for checksums, never the decision
+#: about which checksum to use: that is made per file, from the `ETag` actually
+#: returned. A wrong guess therefore costs at most one needless request, or
+#: falls back to today's behaviour; it can never mis-verify a file.
+#:
+#: 1 GiB matches OpenNeuro's observed part size: across ds000117, ds000246,
+#: ds002578, ds004317, and ds005398, the largest single-part file was 929.6 MB
+#: and the smallest multipart one 1175.0 MB, with part counts (`-3` at ~2.7 GB,
+#: `-4` at ~3.2 GB) consistent throughout.
+_MULTIPART_THRESHOLD = 1024**3
+
 
 def _auth_cookies(*, announce: bool = False) -> RequestsCookieJar:
     """Return the API-token cookie jar, or an empty jar when not logged in.
@@ -1210,7 +1225,7 @@ def download(
     target_dir: Path | str | None = None,
     include: Iterable[str] | None = None,
     exclude: Iterable[str] | None = None,
-    verify_hash: bool | Literal["nemar"] = True,
+    verify_hash: bool | Literal["auto", "nemar"] = "auto",
     verify_size: bool = True,
     max_retries: int = 5,
     max_concurrent_downloads: int = 5,
@@ -1265,19 +1280,30 @@ def download(
     verify_hash
         Whether to calculate and verify a hash of each downloaded file.
 
-        - `True` (the default) uses whatever the source announces. OpenNeuro
-          publishes no checksums, so this falls back to the S3 `ETag`, which is
-          an MD5 only for single-part uploads; larger, multipart-uploaded files
-          are left unverified. NEMAR publishes a checksum for every file, so
-          `source="nemar"` always verifies in full.
+        OpenNeuro publishes no checksums of its own, so verification falls back
+        to the S3 `ETag`. That is an MD5 only for single-part uploads;
+        multipart ones (in practice, files of 1 GiB or more) return a
+        digest-of-digests instead and cannot be checked at all. An `ETag` also
+        only ever describes what OpenNeuro has *stored*, so it cannot reveal a
+        file that was already corrupt at rest. NEMAR mirrors OpenNeuro
+        byte-for-byte and publishes a checksum for every file, which closes
+        both gaps.
+
+        - `"auto"` (the default) verifies against NEMAR's checksums when the
+          files being downloaded include one at or above the multipart
+          threshold, and against the `ETag` otherwise. NEMAR is contacted only
+          when it can actually help, so most downloads are unaffected.
+        - `True` verifies using only what the source itself announces, never
+          contacting NEMAR.
+        - `"nemar"` always consults NEMAR, verifying every file it covers
+          regardless of size.
         - `False` disables hash checking.
-        - `"nemar"` downloads from OpenNeuro but verifies against NEMAR's
-          checksums, covering the large files `True` cannot check. NEMAR
-          mirrors OpenNeuro byte-for-byte, so the two agree; the one file NEMAR
-          rewrites (`dataset_description.json`) is excluded. If NEMAR is
-          unreachable, or mirrors a different revision than the one being
-          downloaded, this degrades to the `True` behaviour rather than
-          failing.
+
+        `"auto"` and `"nemar"` apply only to `source="openneuro"`; a NEMAR
+        download already carries its own checksums. The single file NEMAR
+        rewrites (`dataset_description.json`) is never cross-verified. If NEMAR
+        is unreachable, or mirrors a different revision than the one being
+        downloaded, both degrade to the `True` behaviour rather than failing.
     verify_size
         Whether to check if the downloaded file size matches what the server
         announced.
@@ -1396,16 +1422,6 @@ def download(
     all_files = metadata.files
     del metadata
 
-    if verify_hash == "nemar" and source == "openneuro":
-        all_files = _apply_nemar_checksums(
-            all_files,
-            dataset_id=dataset,
-            tag=tag,
-            max_retries=max_retries,
-            retry_backoff=retry_backoff,
-            metadata_timeout=metadata_timeout,
-        )
-
     filenames = [f.filename for f in all_files]
 
     if include:
@@ -1440,6 +1456,26 @@ def download(
                     f"Could not find path in the dataset:\n- {pattern}\n{extra}"
                     "Please check your includes."
                 )
+
+    # NEMAR's checksums only add anything to an *OpenNeuro* download; a NEMAR
+    # download already carries its own. "auto" pays the extra request only when
+    # the files actually being fetched include one too large for OpenNeuro's
+    # `ETag` to describe.
+    if source == "openneuro" and (
+        verify_hash == "nemar"
+        or (
+            verify_hash == "auto"
+            and any((f.size or 0) >= _MULTIPART_THRESHOLD for f in files)
+        )
+    ):
+        files = _apply_nemar_checksums(
+            files,
+            dataset_id=dataset,
+            tag=tag,
+            max_retries=max_retries,
+            retry_backoff=retry_backoff,
+            metadata_timeout=metadata_timeout,
+        )
 
     msg = (
         f"Checking {len(files)} files, downloading as needed "

--- a/src/openneuro/_download.py
+++ b/src/openneuro/_download.py
@@ -4,8 +4,10 @@ The flow is roughly:
 
 download
   _get_download_metadata
-    _check_snapshot_exists
-        _safe_query
+    _get_openneuro_metadata      (source="openneuro")
+      _check_snapshot_exists
+          _safe_query
+    _nemar.get_metadata          (source="nemar")
   _get_local_tag
   _glob.glob_filter
   _download_files
@@ -18,11 +20,10 @@ import asyncio
 import contextlib
 import dataclasses
 import hashlib
-import io
 import json
+import re
 import shlex
 import string
-import sys
 import threading
 import time
 from collections.abc import Coroutine, Iterable
@@ -46,36 +47,14 @@ from rich.progress import (
     TransferSpeedColumn,
 )
 
-from openneuro import __version__, _glob
-from openneuro._config import get_token, init_config
-from openneuro._console import console, cprint
-from openneuro._models import DatasetFile, Snapshot
-
-# niquests verifies TLS certificates against the operating system's native
-# trust store by default (via wassima), which covers users in enterprise
-# environments with custom CAs. No explicit SSL context is required, and the
-# same verification applies across the sync and async sessions used below.
-
-
-def _probe_unicode() -> bool:
-    """Whether the stream the console writes to can encode emoji.
-
-    Jupyter takes the `print()` path in `cprint`, but there both streams are
-    UTF-8 `OutStream`s, so probing stderr answers for it too. `encoding` is
-    typed loosely because it is `None` on a redirected stream such as
-    `io.StringIO` (`contextlib.redirect_stderr`), which must not raise here:
-    this runs at import time.
-    """
-    encoding = getattr(sys.stderr, "encoding", None)
-    if isinstance(encoding, str) and encoding.lower() == "utf-8":
-        return True
-    if isinstance(sys.stderr, io.TextIOWrapper):
-        sys.stderr.reconfigure(encoding="utf-8")
-        return True
-    return False
-
-
-unicode_ok = _probe_unicode()
+from openneuro import __version__, _glob, _nemar
+from openneuro._config import Source, get_source, get_token, init_config
+from openneuro._console import _probe_unicode as _probe_unicode
+from openneuro._console import _unicode, _write_retry, console, cprint
+from openneuro._console import unicode_ok as unicode_ok
+from openneuro._http import allowed_retry_codes, allowed_retry_exceptions
+from openneuro._http import user_agent_header as user_agent_header
+from openneuro._models import ChecksumAlgorithm, DatasetFile, Snapshot
 
 
 def login() -> None:
@@ -84,10 +63,6 @@ def login() -> None:
 
 
 _T = TypeVar("_T")
-
-# HTTP server responses that indicate hopefully intermittent errors that
-# warrant a retry.
-allowed_retry_codes = (408, 500, 502, 503, 504, 522, 524)
 
 
 class _RetryableError(Exception):
@@ -116,6 +91,35 @@ class _FileInfo:
     size: int | None
     outfile: Path
     remote_path: str
+    # Announced up-front by NEMAR's manifest; `None` for OpenNeuro, where the
+    # only available hash is whatever the S3 `ETag` happens to hold.
+    checksum: str | None = None
+    checksum_algorithm: ChecksumAlgorithm | None = None
+
+
+def _make_hasher(algorithm: ChecksumAlgorithm, *, size: int | None) -> "hashlib._Hash":
+    r"""Create a fresh hasher for `algorithm`.
+
+    A *factory* rather than a shared object because a download may hash the
+    same file more than once (verifying an existing file, then re-hashing while
+    resuming), and because the `"git"` algorithm needs its length prefix
+    re-applied each time.
+
+    `"git"` is a git *blob* hash: SHA-1 over ``b"blob <size>\0"`` followed by
+    the contents, so the total size must be known before the first byte is fed
+    in. NEMAR's manifest always announces it.
+    """
+    if algorithm == "md5":
+        return hashlib.md5()
+    if algorithm == "sha256":
+        return hashlib.sha256()
+    if algorithm == "git":
+        if size is None:
+            raise ValueError("A git blob hash requires the file size up front.")
+        hasher = hashlib.sha1()
+        hasher.update(b"blob %d\0" % size)
+        return hasher
+    raise ValueError(f"Unknown checksum algorithm: {algorithm!r}")
 
 
 @dataclasses.dataclass
@@ -129,20 +133,6 @@ class _DownloadStats:
     n_files: int = 0
     n_bytes: int = 0
 
-
-allowed_retry_exceptions = (
-    # Connection errors (refused/reset/aborted) and DNS failures
-    # ("[Errno -3] Temporary failure in name resolution"). Connect timeouts land
-    # here too, since ``ConnectTimeout`` is itself a ``ConnectionError``.
-    niquests.ConnectionError,
-    # Read timeouts are a ``Timeout``, not a ``ConnectionError``, so list them
-    # separately.
-    niquests.ReadTimeout,
-    # Incomplete chunked reads: "peer closed connection without sending
-    # complete message body".
-    niquests.exceptions.ChunkedEncodingError,
-)
-user_agent_header: dict[str, str] = {"user-agent": f"openneuro-py/{__version__}"}
 
 _MAX_CONCURRENT_HEAD_REQUESTS = 50
 
@@ -209,6 +199,24 @@ _debug_hint_template = string.Template(
     "https://github.com/OpenNeuroOrg/openneuro/issues/3145"
 )
 
+_nemar_debug_hint = (
+    "If this is unexpected:\n\n"
+    f"1. Navigate to {_nemar.NEMAR_DATA_URL}/<dataset>/<version>/manifest.json\n"
+    '2. Try to manually download the "bytes_url" for the failing files '
+    "listed above.\n\n"
+    'You can also pass source="openneuro" to download the same data from '
+    "OpenNeuro instead."
+)
+
+# `DatasetDOI` as written by OpenNeuro, e.g. "10.18112/openneuro.ds000117.v1.1.0",
+# and as rewritten by NEMAR, e.g. "10.82901/nemar.on000117" (optionally carrying
+# NEMAR's own ".v1.0.0" suffix, which is deliberately not captured: it is NEMAR's
+# numbering, not an OpenNeuro revision).
+_OPENNEURO_DOI_RE = re.compile(
+    r"^10\.18112/openneuro\.ds(?P<number>\d+)\.v(?P<version>.+)$"
+)
+_NEMAR_DOI_RE = re.compile(r"^10\.82901/nemar\.on(?P<number>\d+)(?:\.v.+)?$")
+
 
 def _auth_cookies(*, announce: bool = False) -> RequestsCookieJar:
     """Return the API-token cookie jar, or an empty jar when not logged in.
@@ -264,17 +272,6 @@ def _safe_query(
     return response_json, False
 
 
-def _write_retry(*, what: str, reason: str, retry: int, backoff: float) -> None:
-    remaining = "1 retry remains" if retry == 1 else f"{retry} retries remain"
-    remaining += f", backing off {backoff:0.1f}s"
-    cprint(
-        _unicode(
-            f"{reason} while {what}, retrying ({remaining})",
-            emoji="🔄",
-        )
-    )
-
-
 def _check_snapshot_exists(
     *, dataset_id: str, tag: str, max_retries: int, retry_backoff: float
 ) -> None:
@@ -302,11 +299,42 @@ def _get_download_metadata(
     *,
     dataset_id: str,
     tag: str | None = None,
+    source: Source = "openneuro",
     max_retries: int,
     retry_backoff: float = 0.5,
     metadata_timeout: float = 15.0,
 ) -> Snapshot:
-    """Retrieve dataset metadata required for the download."""
+    """Retrieve dataset metadata required for the download.
+
+    Dispatches to whichever source was requested. Both return the same
+    `Snapshot`, so the rest of the download is source-agnostic.
+    """
+    if source == "nemar":
+        return _nemar.get_metadata(
+            dataset_id=dataset_id,
+            tag=tag,
+            max_retries=max_retries,
+            retry_backoff=retry_backoff,
+            metadata_timeout=metadata_timeout,
+        )
+    return _get_openneuro_metadata(
+        dataset_id=dataset_id,
+        tag=tag,
+        max_retries=max_retries,
+        retry_backoff=retry_backoff,
+        metadata_timeout=metadata_timeout,
+    )
+
+
+def _get_openneuro_metadata(
+    *,
+    dataset_id: str,
+    tag: str | None = None,
+    max_retries: int,
+    retry_backoff: float = 0.5,
+    metadata_timeout: float = 15.0,
+) -> Snapshot:
+    """Retrieve dataset metadata from OpenNeuro's GraphQL API."""
     if tag is None:
         query = dataset_query_template.substitute(dataset_id=dataset_id)
     else:
@@ -400,6 +428,17 @@ def _retry_request(
     return response_json
 
 
+def _resolve_hint(*, query_str: str, debug_hint: str | None) -> str:
+    """Return the dataset-level debug hint shown alongside failures.
+
+    NEMAR downloads pass their own hint; OpenNeuro downloads build one that
+    walks the user through re-running the GraphQL query by hand.
+    """
+    if debug_hint is not None:
+        return debug_hint
+    return _debug_hint_template.substitute(query_str=query_str)
+
+
 async def _download_file(
     *,
     client: niquests.AsyncSession,
@@ -417,6 +456,9 @@ async def _download_file(
     progress: Progress,
     overall_task: TaskID,
     stats: _DownloadStats,
+    checksum: str | None = None,
+    checksum_algorithm: ChecksumAlgorithm | None = None,
+    debug_hint: str | None = None,
 ) -> None:
     """Download an individual file, retrying on transient errors."""
     try:
@@ -437,6 +479,9 @@ async def _download_file(
                     overall_task=overall_task,
                     is_retry=attempt > 0,
                     stats=stats,
+                    checksum=checksum,
+                    checksum_algorithm=checksum_algorithm,
+                    debug_hint=debug_hint,
                 )
                 return
             except _RetryableError as err:
@@ -463,7 +508,7 @@ async def _download_file(
                     )
                     raise _DownloadError(
                         reason=f"{reason} (failed after {attempts})",
-                        hint=_debug_hint_template.substitute(query_str=query_str),
+                        hint=_resolve_hint(query_str=query_str, debug_hint=debug_hint),
                         url=url,
                     ) from (err.__cause__ or err)
     except _DownloadError as exc:
@@ -493,8 +538,12 @@ async def _attempt_download(
     overall_task: TaskID,
     is_retry: bool,
     stats: _DownloadStats,
+    checksum: str | None = None,
+    checksum_algorithm: ChecksumAlgorithm | None = None,
+    debug_hint: str | None = None,
 ) -> None:
     """Single download attempt (HEAD → local check → GET)."""
+    hint = _resolve_hint(query_str=query_str, debug_hint=debug_hint)
     if outfile.exists():
         local_file_size = outfile.stat().st_size
     else:
@@ -512,7 +561,7 @@ async def _attempt_download(
     # and reading only; tasks may legitimately wait a long time for a
     # connection from the shared session's pool, and the semaphores are the
     # sole concurrency throttle.
-    if url.startswith(_openneuro_url_prefix):
+    if url.startswith((_openneuro_url_prefix, _nemar.NEMAR_DATA_URL)):
         timeout = 60
     else:
         timeout = 5
@@ -528,19 +577,35 @@ async def _attempt_download(
             if not response.ok:
                 raise _DownloadError(
                     reason=f"HEAD request failed with HTTP {response.status_code}",
-                    hint=_debug_hint_template.substitute(query_str=query_str),
+                    hint=hint,
                     url=url,
                 )
             headers = response.headers
     except allowed_retry_exceptions as exc:
         raise _RetryableError from exc
 
-    # Try to get the S3 MD5 hash for the file.
-    etag = headers.get("etag")
-    etag_hash = etag.strip('"') if etag is not None else None
-    remote_file_hash = (
-        etag_hash if (etag_hash is not None and len(etag_hash) == 32) else None
-    )
+    if (
+        checksum is not None
+        and checksum_algorithm is not None
+        # A git blob hash is defined over a length prefix, so without the size
+        # it cannot be computed; skip verification rather than fail the file.
+        and not (checksum_algorithm == "git" and remote_file_size is None)
+    ):
+        # NEMAR announces the checksum (and which algorithm produced it) in its
+        # manifest, so there is nothing to infer.
+        remote_file_hash: str | None = checksum
+        hash_algorithm: ChecksumAlgorithm = checksum_algorithm
+    else:
+        # OpenNeuro publishes no checksum, so fall back to the S3 `ETag`, which
+        # holds the MD5 for single-part uploads. Multipart uploads instead give
+        # a "<hash>-<parts>" digest that is not an MD5 of the contents, so only
+        # a bare 32-character hex value can be trusted here.
+        etag = headers.get("etag")
+        etag_hash = etag.strip('"') if etag is not None else None
+        remote_file_hash = (
+            etag_hash if (etag_hash is not None and len(etag_hash) == 32) else None
+        )
+        hash_algorithm = "md5"
 
     # Phase 2: Local file check (no semaphore held — allows other tasks
     # to use network slots while we do local I/O).
@@ -553,7 +618,7 @@ async def _attempt_download(
         and remote_file_size is not None
         and local_file_size == remote_file_size
     ):
-        hash_ = hashlib.md5()
+        hash_ = _make_hasher(hash_algorithm, size=remote_file_size)
 
         if verify_hash and remote_file_hash is not None:
             async with aiofiles.open(outfile, "rb") as f:
@@ -631,7 +696,7 @@ async def _attempt_download(
                 else:
                     raise _DownloadError(
                         reason=f"HTTP {response.status_code} when trying to download",
-                        hint=_debug_hint_template.substitute(query_str=query_str),
+                        hint=hint,
                         url=url,
                     )
 
@@ -648,6 +713,7 @@ async def _attempt_download(
                     verify_size=verify_size,
                     progress=progress,
                     overall_task=overall_task,
+                    hash_algorithm=hash_algorithm,
                 )
             finally:
                 await response.close()
@@ -673,9 +739,10 @@ async def _retrieve_and_write_to_disk(
     verify_size: bool,
     progress: Progress,
     overall_task: TaskID,
+    hash_algorithm: ChecksumAlgorithm = "md5",
 ) -> int:
     """Stream the response to disk, returning the number of bytes downloaded."""
-    hash = hashlib.md5()
+    hash = _make_hasher(hash_algorithm, size=remote_file_size)
 
     # If we're resuming a download, ensure the already-downloaded
     # parts of the file are fed into the hash function before
@@ -798,6 +865,7 @@ async def _download_files(
     max_concurrent_downloads: int,
     query_str: str,
     stats: _DownloadStats,
+    debug_hint: str | None = None,
 ) -> list[tuple[str, _DownloadError]]:
     """Download files concurrently, returning a list of per-file failures."""
     # Semaphore (counter) to limit maximum number of concurrent download
@@ -836,6 +904,8 @@ async def _download_files(
                 size=file.size,
                 outfile=outfile,
                 remote_path=file.filename,
+                checksum=file.checksum,
+                checksum_algorithm=file.checksum_algorithm,
             )
         )
 
@@ -876,6 +946,9 @@ async def _download_files(
                     progress=progress,
                     overall_task=overall_task,
                     stats=stats,
+                    checksum=fi.checksum,
+                    checksum_algorithm=fi.checksum_algorithm,
+                    debug_hint=debug_hint,
                 )
                 for fi in file_infos
             ]
@@ -921,17 +994,95 @@ async def _download_files(
     return failures
 
 
+def _apply_nemar_checksums(
+    files: list[DatasetFile],
+    *,
+    dataset_id: str,
+    tag: str,
+    max_retries: int,
+    retry_backoff: float,
+    metadata_timeout: float,
+) -> list[DatasetFile]:
+    """Attach NEMAR's checksums to OpenNeuro files, where they apply.
+
+    Returns the list unchanged when NEMAR cannot vouch for this revision, so a
+    download never fails merely because the mirror was unavailable.
+    """
+    checksums = _nemar.get_checksums(
+        dataset_id=dataset_id,
+        tag=tag,
+        max_retries=max_retries,
+        retry_backoff=retry_backoff,
+        metadata_timeout=metadata_timeout,
+    )
+    if not checksums:
+        return files
+
+    updated: list[DatasetFile] = []
+    for file in files:
+        entry = checksums.get(file.filename)
+        if entry is None:
+            updated.append(file)
+            continue
+        checksum, algorithm = entry
+        updated.append(
+            file.model_copy(
+                update={"checksum": checksum, "checksum_algorithm": algorithm}
+            )
+        )
+
+    n = sum(f.checksum is not None for f in updated)
+    cprint(
+        _unicode(
+            f"Verifying {n} of {len(updated)} files against NEMAR's checksums",
+            emoji="🔎",
+            end="",
+        )
+    )
+    return updated
+
+
+def _source_dataset_tag(local_json: dict[str, Any]) -> str | None:
+    """Recover the OpenNeuro revision a NEMAR mirror was made from.
+
+    NEMAR replaces `DatasetDOI` with its own identifier but records the
+    OpenNeuro DOI it copied under BIDS' `SourceDatasets`, so a directory filled
+    from NEMAR can still report a meaningful OpenNeuro revision. Returns `None`
+    when no such record is present.
+    """
+    for entry in local_json.get("SourceDatasets") or []:
+        if not isinstance(entry, dict):
+            continue
+        doi = str(entry.get("DOI", "")).removeprefix("doi:")
+        match = _OPENNEURO_DOI_RE.match(doi)
+        if match is not None:
+            return match["version"]
+    return None
+
+
 def _get_local_tag(*, dataset_id: str, dataset_dir: Path) -> str | None:
     """Get the local dataset revision."""
     local_json_path = dataset_dir / "dataset_description.json"
     if not local_json_path.exists():
         return None
 
-    local_json_file_content = local_json_path.read_text(encoding="utf-8")
+    try:
+        local_json_file_content = local_json_path.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        # Damaged beyond recognition; treat the revision as unknown so the
+        # download can replace the file rather than aborting on it.
+        return None
     if not local_json_file_content:
         return None
 
-    local_json = json.loads(local_json_file_content)
+    try:
+        local_json = json.loads(local_json_file_content)
+    except json.JSONDecodeError:
+        # As above: a truncated or corrupt description should be re-downloaded,
+        # not raised as a bare decode error the user cannot act on.
+        return None
+    if not isinstance(local_json, dict):
+        return None
 
     if "DatasetDOI" not in local_json:
         raise RuntimeError(
@@ -946,9 +1097,14 @@ def _get_local_tag(*, dataset_id: str, dataset_dir: Path) -> str | None:
         # Remove the "protocol" prefix
         local_doi = local_doi[4:]
 
-    expected_doi_start = f"10.18112/openneuro.{dataset_id}.v"
-
-    if not local_doi.startswith(expected_doi_start):
+    openneuro_doi = _OPENNEURO_DOI_RE.match(local_doi)
+    # NEMAR rewrites `DatasetDOI` to point at its own mirror, so a directory
+    # previously filled from NEMAR carries a NEMAR DOI even though the bytes
+    # are OpenNeuro's. Recognise both, and compare the dataset *number* so that
+    # a directory populated from one source can be topped up from the other.
+    nemar_doi = _NEMAR_DOI_RE.match(local_doi)
+    match = openneuro_doi or nemar_doi
+    if match is None or match["number"] != dataset_id.removeprefix("ds"):
         raise RuntimeError(
             f"The existing dataset in the target directory "
             f"appears to be different from the one you "
@@ -958,16 +1114,12 @@ def _get_local_tag(*, dataset_id: str, dataset_dir: Path) -> str | None:
             f"Requested dataset: {dataset_id}"
         )
 
-    local_version = local_doi.replace(f"10.18112/openneuro.{dataset_id}.v", "")
-    return local_version
-
-
-def _unicode(msg: str, *, emoji: str = " ", end: str = "…") -> str:
-    if unicode_ok:
-        msg = f"{emoji} {msg} {end}"
-    elif end == "…":
-        msg = f"{msg} ..."
-    return msg
+    if openneuro_doi is None:
+        # NEMAR's own DOI carries its own version numbering, which says nothing
+        # about the OpenNeuro revision. It does record the revision it mirrored
+        # under "SourceDatasets", though, so prefer that over giving up.
+        return _source_dataset_tag(local_json)
+    return openneuro_doi["version"]
 
 
 def _print_download_failures(failures: list[tuple[str, _DownloadError]]) -> None:
@@ -1058,11 +1210,12 @@ def download(
     target_dir: Path | str | None = None,
     include: Iterable[str] | None = None,
     exclude: Iterable[str] | None = None,
-    verify_hash: bool = True,
+    verify_hash: bool | Literal["nemar"] = True,
     verify_size: bool = True,
     max_retries: int = 5,
     max_concurrent_downloads: int = 5,
     metadata_timeout: float = 15.0,
+    source: Source | None = None,
 ) -> None:
     """Download datasets from OpenNeuro.
 
@@ -1071,7 +1224,14 @@ def download(
     dataset
         The dataset to retrieve, for example `ds000248`.
     tag
-        The tag (revision) of the dataset to retrieve.
+        The tag (revision) of the dataset to retrieve. This always refers to an
+        **OpenNeuro** revision, including when `source="nemar"`: NEMAR numbers
+        its mirrors independently, so its own version numbers are never
+        accepted here.
+
+        > **Note:** NEMAR mirrors only a single snapshot per dataset, so
+        > requesting any revision other than the one it currently holds will
+        > fail. Use `source="openneuro"` to fetch an older revision.
     target_dir
         The directory in which to store the downloaded data. If `None`,
         create a subdirectory with the dataset name in the current working
@@ -1103,7 +1263,21 @@ def download(
         > though other dotfiles are skipped by default, because BIDS validators
         > rely on it to know which files to ignore.
     verify_hash
-        Whether to calculate and verify the MD5 hash of each downloaded file.
+        Whether to calculate and verify a hash of each downloaded file.
+
+        - `True` (the default) uses whatever the source announces. OpenNeuro
+          publishes no checksums, so this falls back to the S3 `ETag`, which is
+          an MD5 only for single-part uploads; larger, multipart-uploaded files
+          are left unverified. NEMAR publishes a checksum for every file, so
+          `source="nemar"` always verifies in full.
+        - `False` disables hash checking.
+        - `"nemar"` downloads from OpenNeuro but verifies against NEMAR's
+          checksums, covering the large files `True` cannot check. NEMAR
+          mirrors OpenNeuro byte-for-byte, so the two agree; the one file NEMAR
+          rewrites (`dataset_description.json`) is excluded. If NEMAR is
+          unreachable, or mirrors a different revision than the one being
+          downloaded, this degrades to the `True` behaviour rather than
+          failing.
     verify_size
         Whether to check if the downloaded file size matches what the server
         announced.
@@ -1113,10 +1287,25 @@ def download(
         The maximum number of downloads to run in parallel.
     metadata_timeout
         Timeout in seconds for metadata queries.
+    source
+        Where to fetch the data from.
+
+        - `"openneuro"` (the default) uses OpenNeuro itself, and is the only
+          source that can serve restricted datasets, arbitrary revisions, and
+          non-MEEG modalities.
+        - `"nemar"` uses the NEMAR mirror at UC San Diego
+          (<https://nemar.org>), which carries the EEG, MEG, and iEEG datasets
+          published on OpenNeuro. The files are byte-for-byte identical, and
+          NEMAR publishes per-file checksums that are verified during the
+          download.
+
+        If `None`, the `OPENNEURO_SOURCE` environment variable is consulted,
+        falling back to `"openneuro"`.
 
     """
     if max_concurrent_downloads < 1:
         raise ValueError("max_concurrent_downloads must be at least 1.")
+    source = get_source(source)
 
     msg_problems = "problems 🤯" if unicode_ok else "problems"
     msg_bugs = "bugs 🪲" if unicode_ok else "bugs"
@@ -1133,7 +1322,8 @@ def download(
         f"      https://github.com/openneuro-py/openneuro-py/issues\n"
     )
     cprint(msg)
-    cprint(_unicode(f"Preparing to download {dataset}", emoji="🌍"))
+    where = f"{dataset} from NEMAR" if source == "nemar" else dataset
+    cprint(_unicode(f"Preparing to download {where}", emoji="🌍"))
 
     if target_dir is None:
         target_dir = Path(dataset)
@@ -1151,6 +1341,7 @@ def download(
     metadata = _get_download_metadata(
         dataset_id=dataset,
         tag=tag,
+        source=source,
         max_retries=max_retries,
         retry_backoff=retry_backoff,
         metadata_timeout=metadata_timeout,
@@ -1165,7 +1356,16 @@ def download(
         if not target_dir_empty:
             local_tag = _get_local_tag(dataset_id=dataset, dataset_dir=target_dir)
 
-            if local_tag is None:
+            if local_tag is None and source == "nemar":
+                # Expected, not a warning sign: NEMAR rewrites `DatasetDOI` to
+                # its own identifier, which carries no OpenNeuro revision. The
+                # per-file checksums still catch any stale or corrupt file.
+                cprint(
+                    "The existing files carry NEMAR's identifier rather than "
+                    "an OpenNeuro revision, so the local revision cannot be "
+                    "determined. Each file is verified individually regardless."
+                )
+            elif local_tag is None:
                 cprint(
                     "Cannot determine local revision of the dataset, "
                     "and the target directory is not empty. If the "
@@ -1185,12 +1385,27 @@ def download(
         "participants.tsv",
         "participants.json",
         "README",
+        # BIDS allows the README to carry an extension, and NEMAR stores it as
+        # "README.md" even where OpenNeuro has a plain "README". Names that the
+        # dataset does not contain are simply ignored below.
+        "README.md",
         "CHANGES",
         ".bidsignore",
     }
 
     all_files = metadata.files
     del metadata
+
+    if verify_hash == "nemar" and source == "openneuro":
+        all_files = _apply_nemar_checksums(
+            all_files,
+            dataset_id=dataset,
+            tag=tag,
+            max_retries=max_retries,
+            retry_backoff=retry_backoff,
+            metadata_timeout=metadata_timeout,
+        )
+
     filenames = [f.filename for f in all_files]
 
     if include:
@@ -1242,13 +1457,16 @@ def download(
     coroutine = _download_files(
         target_dir=target_dir,
         files=files,
-        verify_hash=verify_hash,
+        # "nemar" has done its work above, by attaching checksums to the files;
+        # from here on it simply means "verify".
+        verify_hash=bool(verify_hash),
         verify_size=verify_size,
         max_retries=max_retries,
         retry_backoff=retry_backoff,
         max_concurrent_downloads=max_concurrent_downloads,
         query_str=query_str,
         stats=stats,
+        debug_hint=_nemar_debug_hint if source == "nemar" else None,
     )
 
     # Block until the download actually finishes, even when a loop is already

--- a/src/openneuro/_http.py
+++ b/src/openneuro/_http.py
@@ -1,0 +1,33 @@
+"""HTTP constants shared by the metadata and download paths.
+
+These live in their own module so that `_download` and `_nemar` can both use
+them without importing one another.
+
+niquests verifies TLS certificates against the operating system's native trust
+store by default (via wassima), which covers users in enterprise environments
+with custom CAs. No explicit SSL context is required, and the same verification
+applies across the sync and async sessions used throughout the package.
+"""
+
+import niquests
+
+from openneuro import __version__
+
+user_agent_header: dict[str, str] = {"user-agent": f"openneuro-py/{__version__}"}
+
+# HTTP server responses that indicate hopefully intermittent errors that
+# warrant a retry.
+allowed_retry_codes = (408, 500, 502, 503, 504, 522, 524)
+
+allowed_retry_exceptions = (
+    # Connection errors (refused/reset/aborted) and DNS failures
+    # ("[Errno -3] Temporary failure in name resolution"). Connect timeouts land
+    # here too, since ``ConnectTimeout`` is itself a ``ConnectionError``.
+    niquests.ConnectionError,
+    # Read timeouts are a ``Timeout``, not a ``ConnectionError``, so list them
+    # separately.
+    niquests.ReadTimeout,
+    # Incomplete chunked reads: "peer closed connection without sending
+    # complete message body".
+    niquests.exceptions.ChunkedEncodingError,
+)

--- a/src/openneuro/_models.py
+++ b/src/openneuro/_models.py
@@ -1,11 +1,24 @@
-"""Pydantic models for validating OpenNeuro GraphQL API responses.
+"""Pydantic models for validating dataset metadata responses.
 
 Only the inner payload objects (snapshots, files) are modeled here.
 The outer GraphQL response envelope (`{"data": {"dataset": ...}}`) is
 traversed with plain dict access in the download module.
+
+The same models describe files served by the NEMAR mirror (see
+`openneuro._nemar`), whose manifest additionally carries a per-file
+checksum. OpenNeuro's GraphQL API does not expose one, so the checksum
+fields are optional and left unset there.
 """
 
+from typing import Literal
+
 from pydantic import BaseModel
+
+#: Checksum algorithms that may appear in a NEMAR manifest.
+#:
+#: `"git"` is a git *blob* hash: SHA-1 over ``b"blob <size>\0"`` followed by
+#: the file contents, not a plain SHA-1 of the contents.
+ChecksumAlgorithm = Literal["md5", "sha256", "git"]
 
 
 class DatasetFile(BaseModel):
@@ -15,6 +28,8 @@ class DatasetFile(BaseModel):
     urls: list[str] | None = None
     size: int | None = None
     id: str
+    checksum: str | None = None
+    checksum_algorithm: ChecksumAlgorithm | None = None
 
 
 class Snapshot(BaseModel):

--- a/src/openneuro/_nemar.py
+++ b/src/openneuro/_nemar.py
@@ -1,0 +1,418 @@
+"""Support for downloading OpenNeuro datasets from the NEMAR mirror.
+
+NEMAR (<https://nemar.org>) is a partner archive at UC San Diego that mirrors
+every publicly released EEG, MEG, and iEEG dataset from OpenNeuro. The bytes it
+serves are the same bytes OpenNeuro serves; only the way they are addressed
+differs, so this module's job is to translate NEMAR's data API into the same
+`Snapshot` that `_download._get_download_metadata` builds from OpenNeuro's
+GraphQL API. Everything downstream — globbing, resuming, hashing, retrying —
+is shared.
+
+Three differences matter enough to be visible to callers:
+
+1. **Coverage.** Only MEEG datasets are mirrored, so a dataset that exists on
+   OpenNeuro may legitimately be absent here (`_NotFound` → a `RuntimeError`
+   naming `source="openneuro"` as the way out).
+2. **Versioning.** NEMAR assigns its *own* version numbers, which do not
+   correspond to OpenNeuro's tags: NEMAR `v1.0.2` of `on002578` mirrors
+   OpenNeuro's `1.1.0`, and a dataset can be re-released on NEMAR without any
+   upstream change. `tag` therefore always means the *OpenNeuro* tag, and it is
+   resolved through the `IsDerivedFrom` DOI that NEMAR records in its
+   dataset-level metadata. NEMAR keeps only the snapshot it last mirrored, so
+   older OpenNeuro revisions are simply unavailable here.
+3. **Checksums.** Unlike OpenNeuro, NEMAR publishes a per-file checksum in its
+   manifest, which `_download` verifies directly instead of falling back to
+   guessing an MD5 out of the S3 `ETag`.
+"""
+
+import json
+import re
+import time
+from typing import Any
+
+import niquests
+
+from openneuro._console import _write_retry, cprint
+from openneuro._http import allowed_retry_codes, allowed_retry_exceptions
+from openneuro._http import user_agent_header as user_agent_header
+from openneuro._models import ChecksumAlgorithm, DatasetFile, Snapshot
+
+#: Canonical host for NEMAR's data API. `api.nemar.org/data/` is an alias.
+NEMAR_DATA_URL = "https://data.nemar.org"
+
+#: OpenNeuro dataset IDs (``ds<6 digits>``) map onto NEMAR's mirrored IDs
+#: (``on<the same 6 digits>``). NEMAR-native datasets use an ``nm`` prefix and
+#: have no OpenNeuro counterpart, so they are not reachable through this
+#: package.
+_DATASET_ID_RE = re.compile(r"^ds(?P<number>\d+)$")
+
+#: The DOI NEMAR records to state which OpenNeuro revision a mirror came from,
+#: e.g. ``10.18112/openneuro.ds004840.v1.0.1``.
+_OPENNEURO_DOI_RE = re.compile(
+    r"^10\.18112/openneuro\.(?P<dataset_id>ds\d+)\.v(?P<tag>.+)$"
+)
+
+
+class _NotFound(Exception):
+    """Raised when NEMAR answers a metadata request with HTTP 404."""
+
+
+def to_nemar_id(dataset_id: str) -> str:
+    """Translate an OpenNeuro dataset ID into its NEMAR counterpart.
+
+    Parameters
+    ----------
+    dataset_id
+        An OpenNeuro dataset ID, for example `ds004840`.
+
+    Returns
+    -------
+    The corresponding NEMAR dataset ID, for example `on004840`.
+
+    Raises
+    ------
+    ValueError
+        When `dataset_id` is not a well-formed OpenNeuro dataset ID.
+
+    """
+    match = _DATASET_ID_RE.match(dataset_id)
+    if match is None:
+        raise ValueError(
+            f"Cannot download {dataset_id!r} from NEMAR: only OpenNeuro dataset "
+            'IDs of the form "ds<number>" (e.g. ds004840) are mirrored there.'
+        )
+    return f"on{match['number']}"
+
+
+def _get_json(
+    url: str,
+    *,
+    what: str,
+    timeout: float,
+    max_retries: int,
+    retry_backoff: float,
+) -> Any:
+    """GET a JSON document from NEMAR, retrying transient failures.
+
+    Mirrors the retry behaviour of `_download._retry_request` so that a flaky
+    connection behaves the same whichever source is in use.
+    """
+    response: niquests.Response | None = None
+    for retry in reversed(range(max_retries + 1)):
+        request_timed_out = False
+        try:
+            with niquests.Session(
+                # Race IPv6/IPv4 connections (RFC 8305) so a broken stack (e.g.,
+                # non-working IPv6) does not stall or fail the request.
+                happy_eyeballs=True,
+            ) as client:
+                response = client.get(url, timeout=timeout, headers=user_agent_header)
+        except allowed_retry_exceptions:
+            request_timed_out = True
+        else:
+            if response.status_code in allowed_retry_codes:
+                request_timed_out = True
+
+        if not request_timed_out:
+            break
+        if retry > 0:
+            _write_retry(
+                what=what,
+                reason="Request timed out",
+                retry=retry,
+                backoff=retry_backoff,
+            )
+            time.sleep(retry_backoff)
+            retry_backoff *= 2
+    else:
+        raise RuntimeError(f"Timeout when {what}.")
+
+    assert response is not None  # a non-timed-out iteration always sets it
+    if response.status_code == 404:
+        raise _NotFound(url)
+    if not response.ok:
+        raise RuntimeError(f"Error when {what}: HTTP {response.status_code}.")
+    try:
+        return response.json()
+    except json.JSONDecodeError:
+        raise RuntimeError(
+            f"The NEMAR API returned a non-JSON response when {what}. "
+            "Please open an issue at "
+            "https://github.com/openneuro-py/openneuro-py/issues"
+        )
+
+
+def _openneuro_tag_from_metadata(metadata: Any) -> str | None:
+    """Extract the OpenNeuro tag a NEMAR mirror was derived from.
+
+    NEMAR records this as an `IsDerivedFrom` related identifier pointing at the
+    versioned OpenNeuro DOI. Returns `None` when the record is missing or does
+    not look like an OpenNeuro DOI, which callers treat as "provenance unknown"
+    rather than as an error.
+    """
+    if not isinstance(metadata, dict):
+        return None
+    for identifier in metadata.get("related_identifiers") or []:
+        if not isinstance(identifier, dict):
+            continue
+        if identifier.get("relation_type") != "IsDerivedFrom":
+            continue
+        match = _OPENNEURO_DOI_RE.match(str(identifier.get("identifier", "")))
+        if match is not None:
+            return match["tag"]
+    return None
+
+
+def _files_from_manifest(
+    manifest: Any, *, nemar_id: str, version: str
+) -> list[DatasetFile]:
+    """Convert a NEMAR manifest into `DatasetFile`s."""
+    if not isinstance(manifest, list):
+        raise RuntimeError(
+            f"The NEMAR manifest for {nemar_id} {version} was not a list. "
+            "Please open an issue at "
+            "https://github.com/openneuro-py/openneuro-py/issues"
+        )
+
+    files: list[DatasetFile] = []
+    for entry in manifest:
+        if not isinstance(entry, dict) or "path" not in entry:
+            continue
+        path = str(entry["path"])
+        # `url` is a pre-signed S3 link that expires after an hour, which is
+        # not long enough for a large dataset. `bytes_url` is the stable
+        # address that mints a fresh pre-signed link on every request (or, for
+        # small git-stored files, points straight at raw.githubusercontent.com),
+        # so it is the one that survives a long or resumed download.
+        url = entry.get("bytes_url") or entry.get("url")
+        files.append(
+            DatasetFile(
+                filename=path,
+                urls=[str(url)] if url else None,
+                size=entry.get("size"),
+                # NEMAR has no per-file opaque ID; the path is unique already.
+                id=path,
+                checksum=entry.get("checksum"),
+                checksum_algorithm=entry.get("checksum_algorithm"),
+            )
+        )
+    return files
+
+
+def get_metadata(
+    *,
+    dataset_id: str,
+    tag: str | None,
+    max_retries: int,
+    retry_backoff: float,
+    metadata_timeout: float,
+) -> Snapshot:
+    """Retrieve the metadata needed to download `dataset_id` from NEMAR.
+
+    Parameters
+    ----------
+    dataset_id
+        The OpenNeuro dataset ID, for example `ds004840`.
+    tag
+        The requested **OpenNeuro** tag (revision), or `None` for whichever
+        revision NEMAR currently mirrors.
+    max_retries
+        How many times to retry a timed-out metadata request.
+    retry_backoff
+        Seconds to wait before the first retry; doubled on each subsequent one.
+    metadata_timeout
+        Per-request timeout in seconds.
+
+    Returns
+    -------
+    A `Snapshot` whose `id` is `"<dataset_id>:<openneuro_tag>"`, matching what
+    the OpenNeuro path returns so that the rest of the download is identical.
+
+    """
+    nemar_id = to_nemar_id(dataset_id)
+
+    try:
+        versions_doc = _get_json(
+            f"{NEMAR_DATA_URL}/{nemar_id}/",
+            what=f"retrieving NEMAR versions for {dataset_id}",
+            timeout=metadata_timeout,
+            max_retries=max_retries,
+            retry_backoff=retry_backoff,
+        )
+    except _NotFound:
+        raise RuntimeError(_not_mirrored_message(dataset_id))
+
+    version = (
+        (versions_doc or {}).get("latest") if isinstance(versions_doc, dict) else None
+    )
+    if not version:
+        raise RuntimeError(
+            f"NEMAR lists {dataset_id} (as {nemar_id}) but has not published "
+            "any version of it yet, so there is nothing to download. Pass "
+            'source="openneuro" to download it from OpenNeuro instead.'
+        )
+
+    # NEMAR's dataset-level metadata describes its latest version, which is the
+    # one we are about to download.
+    try:
+        metadata_doc = _get_json(
+            f"{NEMAR_DATA_URL}/{nemar_id}/metadata.json",
+            what=f"retrieving NEMAR metadata for {dataset_id}",
+            timeout=metadata_timeout,
+            max_retries=max_retries,
+            retry_backoff=retry_backoff,
+        )
+    except _NotFound:
+        metadata_doc = None
+    openneuro_tag = _openneuro_tag_from_metadata(metadata_doc)
+
+    if openneuro_tag is None:
+        # Without the provenance record we cannot honour, or even report, an
+        # OpenNeuro revision. That is fatal only if one was actually requested.
+        if tag is not None:
+            raise RuntimeError(
+                f"NEMAR does not record which OpenNeuro revision of "
+                f"{dataset_id} it mirrors, so revision {tag} cannot be "
+                'requested from it. Pass source="openneuro" to download that '
+                "revision from OpenNeuro instead."
+            )
+        cprint(
+            f"NEMAR does not record which OpenNeuro revision of {dataset_id} "
+            f"it mirrors; reporting its own version ({version}) instead."
+        )
+        reported_tag = version
+    elif tag is not None and tag != openneuro_tag:
+        raise RuntimeError(
+            f"NEMAR does not provide revision {tag} of {dataset_id}.\n\n"
+            f"NEMAR mirrors a single snapshot per dataset, and currently holds "
+            f"OpenNeuro revision {openneuro_tag} (as NEMAR version {version}). "
+            f'Either request tag="{openneuro_tag}", or pass '
+            'source="openneuro" to download revision '
+            f"{tag} from OpenNeuro instead."
+        )
+    else:
+        reported_tag = openneuro_tag
+
+    try:
+        manifest = _get_json(
+            f"{NEMAR_DATA_URL}/{nemar_id}/{version}/manifest.json",
+            what=f"retrieving NEMAR file manifest for {dataset_id}",
+            timeout=metadata_timeout,
+            max_retries=max_retries,
+            retry_backoff=retry_backoff,
+        )
+    except _NotFound:
+        raise RuntimeError(
+            f"NEMAR has no file manifest for {dataset_id} version {version}. "
+            'Pass source="openneuro" to download it from OpenNeuro instead.'
+        )
+
+    files = _files_from_manifest(manifest, nemar_id=nemar_id, version=version)
+    if not files:
+        raise RuntimeError(
+            f"The NEMAR manifest for {dataset_id} version {version} lists no "
+            'files. Pass source="openneuro" to download it from OpenNeuro '
+            "instead."
+        )
+
+    return Snapshot(id=f"{dataset_id}:{reported_tag}", files=files)
+
+
+def _not_mirrored_message(dataset_id: str) -> str:
+    """Explain that NEMAR does not carry `dataset_id`."""
+    return (
+        f"Dataset {dataset_id} is not available from NEMAR.\n\n"
+        "NEMAR mirrors the EEG, MEG, and iEEG datasets published on OpenNeuro, "
+        "so datasets of other modalities — and datasets that have not been "
+        'mirrored yet — are not available there. Pass source="openneuro" to '
+        "download it from OpenNeuro instead."
+    )
+
+
+#: Files NEMAR rewrites while mirroring, whose checksums therefore describe
+#: NEMAR's copy rather than OpenNeuro's and must never be used to verify an
+#: OpenNeuro download.
+#:
+#: NEMAR repoints ``DatasetDOI`` at its own identifier and records the OpenNeuro
+#: one under ``SourceDatasets``, which changes the file. Measured across
+#: ds000117, ds000246, and ds004840, this is the *only* difference: of 709
+#: git-hashed and 87 md5-hashed files compared against OpenNeuro, every other
+#: one matched byte-for-byte.
+_REWRITTEN_BY_NEMAR = frozenset({"dataset_description.json"})
+
+
+def get_checksums(
+    *,
+    dataset_id: str,
+    tag: str,
+    max_retries: int,
+    retry_backoff: float,
+    metadata_timeout: float,
+) -> dict[str, tuple[str, ChecksumAlgorithm]]:
+    """Fetch NEMAR's checksums for verifying an *OpenNeuro* download.
+
+    OpenNeuro publishes no checksums of its own; `_download` falls back to the
+    S3 `ETag`, which is an MD5 only for single-part uploads. Multipart uploads
+    return a `"<hash>-<parts>"` digest instead, so the very largest files —
+    the ones most likely to arrive truncated — currently go unverified. Because
+    NEMAR mirrors OpenNeuro byte-for-byte, its manifest can supply the missing
+    checksums.
+
+    This is a best-effort enhancement layered on top of an OpenNeuro download,
+    so every failure path degrades to the normal `ETag` behaviour rather than
+    raising: NEMAR being unreachable must not break a download that OpenNeuro
+    is happily serving.
+
+    Parameters
+    ----------
+    dataset_id
+        The OpenNeuro dataset ID, for example `ds000246`.
+    tag
+        The OpenNeuro revision being downloaded. Checksums are returned only if
+        NEMAR mirrors exactly this revision; a mirror that has fallen behind
+        describes different bytes and is refused.
+    max_retries
+        How many times to retry a timed-out metadata request.
+    retry_backoff
+        Seconds to wait before the first retry; doubled on each subsequent one.
+    metadata_timeout
+        Per-request timeout in seconds.
+
+    Returns
+    -------
+    A mapping of dataset-relative path to `(checksum, algorithm)`, empty when
+    NEMAR cannot vouch for this revision.
+
+    """
+    try:
+        snapshot = get_metadata(
+            dataset_id=dataset_id,
+            tag=None,  # resolve whatever NEMAR holds, then compare below
+            max_retries=max_retries,
+            retry_backoff=retry_backoff,
+            metadata_timeout=metadata_timeout,
+        )
+    except (RuntimeError, ValueError) as exc:
+        reason = str(exc).splitlines()[0]
+        cprint(
+            f"Could not get extra checksums from NEMAR ({reason}) "
+            "Continuing with OpenNeuro's own verification."
+        )
+        return {}
+
+    mirrored_tag = snapshot.id.removeprefix(f"{dataset_id}:")
+    if mirrored_tag != tag:
+        cprint(
+            f"NEMAR mirrors revision {mirrored_tag} of {dataset_id}, but "
+            f"revision {tag} is being downloaded, so its checksums do not "
+            "apply. Continuing with OpenNeuro's own verification."
+        )
+        return {}
+
+    return {
+        f.filename: (f.checksum, f.checksum_algorithm)
+        for f in snapshot.files
+        if f.checksum is not None
+        and f.checksum_algorithm is not None
+        and f.filename not in _REWRITTEN_BY_NEMAR
+    }

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,9 +3,18 @@
 from pathlib import Path
 from unittest import mock
 
+import pytest
+
 import openneuro
 import openneuro._config
-from openneuro._config import Config, get_token, init_config, load_config
+from openneuro._config import (
+    SOURCE_ENV_VAR,
+    Config,
+    get_source,
+    get_token,
+    init_config,
+    load_config,
+)
 
 
 def test_config(tmp_path: Path):
@@ -20,3 +29,47 @@ def test_config(tmp_path: Path):
         expected_config = Config(endpoint="https://openneuro.org/", apikey="test")
         assert load_config() == expected_config
         assert get_token() == "test"
+
+
+@pytest.mark.parametrize(
+    ("explicit", "env", "expected"),
+    [
+        # Nothing set anywhere.
+        (None, None, "openneuro"),
+        # The environment variable supplies the default...
+        (None, "nemar", "nemar"),
+        (None, "openneuro", "openneuro"),
+        # ...but an explicit argument always wins over it.
+        ("openneuro", "nemar", "openneuro"),
+        ("nemar", "openneuro", "nemar"),
+        # Blank/whitespace env vars are treated as unset.
+        (None, "", "openneuro"),
+        (None, "   ", "openneuro"),
+    ],
+)
+def test_get_source(
+    monkeypatch: pytest.MonkeyPatch,
+    explicit: str | None,
+    env: str | None,
+    expected: str,
+):
+    """Resolve the download source from the argument, then the environment."""
+    if env is None:
+        monkeypatch.delenv(SOURCE_ENV_VAR, raising=False)
+    else:
+        monkeypatch.setenv(SOURCE_ENV_VAR, env)
+    assert get_source(explicit) == expected  # type: ignore[arg-type]
+
+
+def test_get_source_rejects_unknown_argument(monkeypatch: pytest.MonkeyPatch):
+    """An unknown explicit source names the valid choices."""
+    monkeypatch.delenv(SOURCE_ENV_VAR, raising=False)
+    with pytest.raises(ValueError, match="The requested source must be one of"):
+        get_source("s3")  # type: ignore[arg-type]
+
+
+def test_get_source_rejects_unknown_env_var(monkeypatch: pytest.MonkeyPatch):
+    """An unknown environment value blames the environment, not the caller."""
+    monkeypatch.setenv(SOURCE_ENV_VAR, "s3")
+    with pytest.raises(ValueError, match=f"The {SOURCE_ENV_VAR} environment variable"):
+        get_source()

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -1633,3 +1633,134 @@ def test_download_uses_source_env_var(tmp_path: Path, monkeypatch: pytest.Monkey
         download(dataset="ds004840", target_dir=tmp_path)
 
     assert mock_metadata.call_args.kwargs["source"] == "nemar"
+
+
+# -- verify_hash="auto": consult NEMAR only when it can help --
+
+
+@pytest.mark.parametrize(
+    ("verify_hash", "source", "sizes", "expected"),
+    [
+        # "auto" asks only when a file too large for OpenNeuro's ETag is in play.
+        ("auto", "openneuro", [_download._MULTIPART_THRESHOLD], True),
+        ("auto", "openneuro", [_download._MULTIPART_THRESHOLD - 1], False),
+        ("auto", "openneuro", [10, 20], False),
+        # Boundary: exactly at the threshold counts, and an unknown size does not.
+        ("auto", "openneuro", [None], False),
+        # "nemar" always asks, "True"/False never do.
+        ("nemar", "openneuro", [10], True),
+        (True, "openneuro", [_download._MULTIPART_THRESHOLD], False),
+        (False, "openneuro", [_download._MULTIPART_THRESHOLD], False),
+        # A NEMAR download already carries checksums, so never ask again.
+        ("auto", "nemar", [_download._MULTIPART_THRESHOLD], False),
+        ("nemar", "nemar", [_download._MULTIPART_THRESHOLD], False),
+    ],
+)
+def test_nemar_checksums_are_requested_only_when_useful(
+    tmp_path: Path, verify_hash, source, sizes, expected
+):
+    """`auto` must pay for the extra request exactly when it buys something."""
+    files = [
+        DatasetFile(
+            filename=f"sub-01/f{i}.bin",
+            urls=[f"https://example.com/{i}"],
+            size=size,
+            id=str(i),
+        )
+        for i, size in enumerate(sizes)
+    ]
+    snapshot = Snapshot(id="ds000246:1.0.1", files=files)
+
+    with (
+        patch.object(_download, "_get_download_metadata", return_value=snapshot),
+        patch.object(_download, "_get_local_tag", return_value=None),
+        patch.object(_download, "_download_files", return_value=[]),
+        patch.object(
+            _download, "_apply_nemar_checksums", side_effect=lambda f, **kw: f
+        ) as mock_apply,
+    ):
+        download(
+            dataset="ds000246",
+            tag="1.0.1",
+            target_dir=tmp_path,
+            verify_hash=verify_hash,
+            source=source,
+        )
+
+    assert mock_apply.called is expected
+
+
+def test_auto_ignores_the_size_of_excluded_files(tmp_path: Path):
+    """A huge file the user excluded must not trigger a NEMAR request."""
+    snapshot = Snapshot(
+        id="ds000246:1.0.1",
+        files=[
+            DatasetFile(
+                filename="sub-01/huge.bin",
+                urls=["https://example.com/huge"],
+                size=_download._MULTIPART_THRESHOLD * 4,
+                id="huge",
+            ),
+            DatasetFile(
+                filename="sub-02/small.bin",
+                urls=["https://example.com/small"],
+                size=10,
+                id="small",
+            ),
+        ],
+    )
+    with (
+        patch.object(_download, "_get_download_metadata", return_value=snapshot),
+        patch.object(_download, "_get_local_tag", return_value=None),
+        patch.object(_download, "_download_files", return_value=[]),
+        patch.object(
+            _download, "_apply_nemar_checksums", side_effect=lambda f, **kw: f
+        ) as mock_apply,
+    ):
+        download(
+            dataset="ds000246",
+            tag="1.0.1",
+            target_dir=tmp_path,
+            include=["sub-02"],
+            verify_hash="auto",
+        )
+
+    assert not mock_apply.called
+
+
+@pytest.mark.parametrize(
+    ("argv", "expected"),
+    [
+        ([], "auto"),
+        (["--nemar-checksums"], "nemar"),
+        (["--no-nemar-checksums"], True),
+        (["--no-verify-hash"], False),
+        (["--no-verify-hash", "--no-nemar-checksums"], False),
+    ],
+)
+def test_verify_hash_cli_mapping(argv, expected):
+    """The CLI flags map onto download()'s verify_hash values."""
+    from typer.testing import CliRunner
+
+    from openneuro._cli import app
+
+    runner = CliRunner()
+    with patch("openneuro._cli.download") as mock_download:
+        result = runner.invoke(app, ["download", "--dataset=ds000246", *argv])
+
+    assert result.exit_code == 0, result.output
+    assert mock_download.call_args.kwargs["verify_hash"] == expected
+
+
+def test_nemar_checksums_conflicts_with_no_verify_hash():
+    """Asking for stricter and no verification at once is refused."""
+    from typer.testing import CliRunner
+
+    from openneuro._cli import app
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["download", "--dataset=ds000246", "--no-verify-hash", "--nemar-checksums"],
+    )
+    assert result.exit_code == 2

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -1497,3 +1497,139 @@ def test_run_coroutine_blocking(loop_already_running: bool):
 
     with pytest.raises(ValueError, match="boom"):
         _run(_boom())
+
+
+# -- NEMAR mirror (gh: source= support) --
+
+
+@pytest.mark.flaky(reruns=3, reruns_delay=5)
+def test_download_from_nemar(tmp_path: Path):
+    """Download from NEMAR, and confirm it matches what OpenNeuro serves.
+
+    NEMAR is a mirror, so the data files must be byte-identical. Only
+    `dataset_description.json` may differ: NEMAR rewrites `DatasetDOI` to its
+    own identifier and records the OpenNeuro one under `SourceDatasets`.
+    """
+    dataset = "ds004840"
+    include = ["sub-01/ses-01/eeg/*preMusicTherapy*"]
+    nemar_dir, openneuro_dir = tmp_path / "nemar", tmp_path / "openneuro"
+
+    download(dataset=dataset, source="nemar", target_dir=nemar_dir, include=include)
+    download(
+        dataset=dataset, source="openneuro", target_dir=openneuro_dir, include=include
+    )
+
+    def contents(root: Path) -> dict[str, bytes]:
+        return {
+            str(p.relative_to(root)): p.read_bytes()
+            for p in root.rglob("*")
+            if p.is_file()
+        }
+
+    from_nemar, from_openneuro = contents(nemar_dir), contents(openneuro_dir)
+    data_files = [
+        name
+        for name in set(from_nemar) & set(from_openneuro)
+        if name != "dataset_description.json"
+    ]
+    assert data_files  # guard against comparing nothing at all
+    for name in data_files:
+        assert from_nemar[name] == from_openneuro[name], name
+
+    # NEMAR stores the README with an extension; it must still arrive, since
+    # the essential BIDS files are downloaded regardless of `include`.
+    assert "README.md" in from_nemar
+    assert "README" in from_openneuro
+
+    # Both directories must report the same OpenNeuro revision, so that one can
+    # be topped up from the other.
+    assert _download._get_local_tag(
+        dataset_id=dataset, dataset_dir=nemar_dir
+    ) == _download._get_local_tag(dataset_id=dataset, dataset_dir=openneuro_dir)
+
+
+@pytest.mark.flaky(reruns=3, reruns_delay=5)
+def test_download_from_nemar_verifies_checksums(tmp_path: Path):
+    """A corrupted file is detected by its checksum and re-downloaded.
+
+    Each file is truncated-in-place to the *same* length as the original, so
+    only the manifest checksum (not the size check) can catch the damage. Both
+    of NEMAR's algorithms are exercised: `sha256` for S3-backed data files and
+    the git blob hash for small git-stored ones.
+    """
+    kwargs = dict(
+        dataset="ds004840",
+        source="nemar",
+        target_dir=tmp_path,
+        include=["sub-01/ses-01/eeg/*preMusicTherapy*"],
+    )
+    download(**kwargs)
+
+    corrupted = {
+        # sha256, served from S3
+        tmp_path / "sub-01/ses-01/eeg/sub-01_ses-01_task-preMusicTherapy_eeg.edf",
+        # git blob hash, served from raw.githubusercontent.com
+        tmp_path / ".bidsignore",
+    }
+    original = {path: path.read_bytes() for path in corrupted}
+    for path, content in original.items():
+        path.write_bytes(bytes(len(content)))
+
+    download(**kwargs)
+
+    for path, content in original.items():
+        assert path.read_bytes() == content, path
+
+
+def test_source_cli_option():
+    """The CLI should forward --source to download()."""
+    from typer.testing import CliRunner
+
+    from openneuro._cli import app
+
+    runner = CliRunner()
+    with patch("openneuro._cli.download") as mock_download:
+        result = runner.invoke(
+            app, ["download", "--dataset=ds004840", "--source=nemar"]
+        )
+
+    assert result.exit_code == 0
+    assert mock_download.call_args.kwargs["source"] == "nemar"
+
+
+def test_source_cli_option_defaults_to_none():
+    """Without --source the CLI defers to download()'s own resolution."""
+    from typer.testing import CliRunner
+
+    from openneuro._cli import app
+
+    runner = CliRunner()
+    with patch("openneuro._cli.download") as mock_download:
+        result = runner.invoke(app, ["download", "--dataset=ds004840"])
+
+    assert result.exit_code == 0
+    assert mock_download.call_args.kwargs["source"] is None
+
+
+def test_source_cli_option_rejects_unknown():
+    """An unknown --source is refused by the CLI parser."""
+    from typer.testing import CliRunner
+
+    from openneuro._cli import app
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["download", "--dataset=ds004840", "--source=s3"])
+    assert result.exit_code == 2
+
+
+def test_download_uses_source_env_var(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """OPENNEURO_SOURCE selects the source when none is passed explicitly."""
+    monkeypatch.setenv("OPENNEURO_SOURCE", "nemar")
+    snapshot = Snapshot(id="ds004840:1.0.1", files=[])
+
+    with patch.object(
+        _download, "_get_download_metadata", return_value=snapshot
+    ) as mock_metadata:
+        download(dataset="ds004840", target_dir=tmp_path)
+
+    assert mock_metadata.call_args.kwargs["source"] == "nemar"

--- a/tests/test_nemar.py
+++ b/tests/test_nemar.py
@@ -8,7 +8,12 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from openneuro import _nemar
-from openneuro._download import _get_local_tag, _make_hasher
+from openneuro._download import (
+    _apply_nemar_checksums,
+    _get_local_tag,
+    _make_hasher,
+)
+from openneuro._models import DatasetFile
 from openneuro._nemar import (
     _files_from_manifest,
     _NotFound,
@@ -457,3 +462,104 @@ def test_get_local_tag_survives_a_corrupt_description(tmp_path: Path):
     # A valid JSON document that is not an object is equally unusable.
     (tmp_path / "dataset_description.json").write_text("[1, 2]", "utf-8")
     assert _get_local_tag(dataset_id="ds004840", dataset_dir=tmp_path) is None
+
+
+# -- cross-source verification: NEMAR checksums for an OpenNeuro download --
+
+
+_CROSS_MANIFEST = [
+    {
+        "path": "sub-01/meg/big.meg4",
+        "size": 1175040008,
+        "checksum_algorithm": "md5",
+        "checksum": "9f8b091f26abb85986ebe68ce48661f3",
+        "bytes_url": "https://data.nemar.org/on000246/v1/sub-01/meg/big.meg4",
+    },
+    {
+        # NEMAR rewrites this one, so its checksum must never be handed out.
+        "path": "dataset_description.json",
+        "size": 996,
+        "checksum_algorithm": "git",
+        "checksum": "deadbeef",
+        "bytes_url": "https://data.nemar.org/on000246/v1/dataset_description.json",
+    },
+]
+
+
+def _cross_responses(metadata=_METADATA):
+    return {
+        "/on000246/": {"dataset_id": "on000246", "latest": "v1.0.0"},
+        "/metadata.json": metadata,
+        "/manifest.json": _CROSS_MANIFEST,
+    }
+
+
+def test_get_checksums_excludes_rewritten_files():
+    """NEMAR's own dataset_description.json must never verify OpenNeuro's."""
+    with patch.object(_nemar, "_get_json", _fake_get_json(_cross_responses())):
+        checksums = _nemar.get_checksums(dataset_id="ds000246", tag="1.0.1", **_KWARGS)
+
+    assert checksums == {
+        "sub-01/meg/big.meg4": ("9f8b091f26abb85986ebe68ce48661f3", "md5")
+    }
+    assert "dataset_description.json" not in checksums
+
+
+def test_get_checksums_refuses_a_different_revision(capsys):
+    """A mirror that has fallen behind describes different bytes."""
+    with patch.object(_nemar, "_get_json", _fake_get_json(_cross_responses())):
+        # NEMAR mirrors 1.0.1 (per _METADATA); we are downloading 1.0.0.
+        checksums = _nemar.get_checksums(dataset_id="ds000246", tag="1.0.0", **_KWARGS)
+
+    assert checksums == {}
+    assert "do not apply" in capsys.readouterr().err
+
+
+def test_get_checksums_degrades_when_nemar_is_unavailable(capsys):
+    """NEMAR being down must not break a working OpenNeuro download."""
+    with patch.object(_nemar, "_get_json", _fake_get_json({})):  # everything 404s
+        checksums = _nemar.get_checksums(dataset_id="ds000246", tag="1.0.1", **_KWARGS)
+
+    assert checksums == {}
+    assert "Continuing with OpenNeuro" in capsys.readouterr().err
+
+
+def test_apply_nemar_checksums_merges_only_matching_files():
+    """Files NEMAR covers gain a checksum; the rest are untouched."""
+    files = [
+        DatasetFile(
+            filename="sub-01/meg/big.meg4", urls=["https://on/big"], size=1, id="a"
+        ),
+        DatasetFile(filename="README", urls=["https://on/readme"], size=2, id="b"),
+    ]
+    with patch.object(_nemar, "_get_json", _fake_get_json(_cross_responses())):
+        merged = _apply_nemar_checksums(
+            files,
+            dataset_id="ds000246",
+            tag="1.0.1",
+            max_retries=0,
+            retry_backoff=0.0,
+            metadata_timeout=1.0,
+        )
+
+    by_name = {f.filename: f for f in merged}
+    assert by_name["sub-01/meg/big.meg4"].checksum_algorithm == "md5"
+    # NEMAR stores the README as README.md, so this one has no counterpart.
+    assert by_name["README"].checksum is None
+    # The originals are left alone rather than mutated in place.
+    assert files[0].checksum is None
+
+
+def test_apply_nemar_checksums_returns_input_when_unavailable():
+    """An unreachable mirror leaves the file list exactly as it was."""
+    files = [DatasetFile(filename="a.txt", urls=["https://on/a"], size=1, id="a")]
+    with patch.object(_nemar, "_get_json", _fake_get_json({})):
+        merged = _apply_nemar_checksums(
+            files,
+            dataset_id="ds000246",
+            tag="1.0.1",
+            max_retries=0,
+            retry_backoff=0.0,
+            metadata_timeout=1.0,
+        )
+    assert merged == files

--- a/tests/test_nemar.py
+++ b/tests/test_nemar.py
@@ -7,13 +7,14 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from openneuro import _nemar
+from openneuro import _download, _nemar
 from openneuro._download import (
     _apply_nemar_checksums,
     _get_local_tag,
     _make_hasher,
+    _make_nemar_debug_hint,
 )
-from openneuro._models import DatasetFile
+from openneuro._models import DatasetFile, Snapshot
 from openneuro._nemar import (
     _files_from_manifest,
     _NotFound,
@@ -563,3 +564,42 @@ def test_apply_nemar_checksums_returns_input_when_unavailable():
             metadata_timeout=1.0,
         )
     assert merged == files
+
+
+# -- failure hints --
+
+
+def test_nemar_debug_hint_uses_resolvable_coordinates():
+    """The hint must not send readers to a URL that 404s.
+
+    NEMAR addresses the dataset by its own ID and its own version numbering, so
+    a hint containing `<dataset>`/`<version>` placeholders invites the reader to
+    substitute the OpenNeuro ones and land on a 404.
+    """
+    hint = _make_nemar_debug_hint("ds004840")
+
+    assert "https://data.nemar.org/on004840/" in hint
+    # Never the OpenNeuro ID as a NEMAR path segment...
+    assert "data.nemar.org/ds004840" not in hint
+    # ...and nothing left for the reader to fill in.
+    assert "<dataset>" not in hint
+    assert "<version>" not in hint
+    # The OpenNeuro ID still appears, to explain the mapping.
+    assert "ds004840" in hint
+    assert 'source="openneuro"' in hint
+
+
+def test_nemar_debug_hint_reaches_failures(tmp_path: Path):
+    """A failing NEMAR download surfaces the NEMAR hint, not the GraphQL one."""
+    snapshot = Snapshot(
+        id="ds004840:1.0.1",
+        files=[DatasetFile(filename="a.bin", urls=None, size=1, id="a")],
+    )
+    with (
+        patch.object(_download, "_get_download_metadata", return_value=snapshot),
+        patch.object(_download, "_get_local_tag", return_value=None),
+        pytest.raises(RuntimeError, match="Failed to download"),
+    ):
+        _download.download(
+            dataset="ds004840", tag="1.0.1", target_dir=tmp_path, source="nemar"
+        )

--- a/tests/test_nemar.py
+++ b/tests/test_nemar.py
@@ -1,0 +1,459 @@
+"""Tests for downloading from the NEMAR mirror."""
+
+import hashlib
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from openneuro import _nemar
+from openneuro._download import _get_local_tag, _make_hasher
+from openneuro._nemar import (
+    _files_from_manifest,
+    _NotFound,
+    _openneuro_tag_from_metadata,
+    get_metadata,
+    to_nemar_id,
+)
+
+# -- dataset ID mapping --
+
+
+@pytest.mark.parametrize(
+    ("dataset_id", "expected"),
+    [
+        ("ds004840", "on004840"),
+        ("ds000117", "on000117"),
+        ("ds1", "on1"),
+    ],
+)
+def test_to_nemar_id(dataset_id: str, expected: str):
+    """OpenNeuro IDs map onto NEMAR IDs by swapping the prefix."""
+    assert to_nemar_id(dataset_id) == expected
+
+
+@pytest.mark.parametrize(
+    "dataset_id",
+    [
+        "on004840",  # already a NEMAR ID
+        "nm000103",  # NEMAR-native, no OpenNeuro counterpart
+        "ds00abcd",  # not numeric
+        "",
+    ],
+)
+def test_to_nemar_id_rejects_non_openneuro_ids(dataset_id: str):
+    """Anything that is not a ``ds<number>`` ID is refused."""
+    with pytest.raises(ValueError, match="ds<number>"):
+        to_nemar_id(dataset_id)
+
+
+# -- provenance --
+
+
+def test_openneuro_tag_from_metadata():
+    """The OpenNeuro revision is read off the IsDerivedFrom DOI."""
+    metadata = {
+        "related_identifiers": [
+            {
+                "identifier": "https://github.com/nemarDatasets/on004840",
+                "relation_type": "IsDescribedBy",
+            },
+            {
+                "identifier": "10.18112/openneuro.ds004840",
+                "relation_type": "IsVersionOf",
+            },
+            {
+                "identifier": "10.18112/openneuro.ds004840.v1.0.1",
+                "relation_type": "IsDerivedFrom",
+            },
+        ]
+    }
+    assert _openneuro_tag_from_metadata(metadata) == "1.0.1"
+
+
+@pytest.mark.parametrize(
+    "metadata",
+    [
+        None,
+        {},
+        {"related_identifiers": None},
+        {"related_identifiers": []},
+        # Present, but not an OpenNeuro DOI.
+        {
+            "related_identifiers": [
+                {
+                    "identifier": "10.82901/nemar.on004840",
+                    "relation_type": "IsDerivedFrom",
+                }
+            ]
+        },
+        # Right DOI, wrong relation.
+        {
+            "related_identifiers": [
+                {
+                    "identifier": "10.18112/openneuro.ds004840.v1.0.1",
+                    "relation_type": "IsVersionOf",
+                }
+            ]
+        },
+    ],
+)
+def test_openneuro_tag_from_metadata_missing(metadata):
+    """Absent or unrecognised provenance reads as "unknown", not an error."""
+    assert _openneuro_tag_from_metadata(metadata) is None
+
+
+# -- manifest parsing --
+
+
+def test_files_from_manifest():
+    """Manifest entries become DatasetFiles, preferring the non-expiring URL."""
+    manifest = [
+        {
+            "path": ".bidsignore",
+            "size": 8,
+            "checksum_algorithm": "git",
+            "checksum": "66fda975",
+            "bytes_url": "https://raw.githubusercontent.com/x/on1/v1/.bidsignore",
+            "url": "https://raw.githubusercontent.com/x/on1/v1/.bidsignore",
+        },
+        {
+            "path": "sub-01/eeg/sub-01_eeg.edf",
+            "size": 22208868,
+            "checksum_algorithm": "sha256",
+            "checksum": "2837b4bd",
+            "bytes_url": "https://data.nemar.org/on1/v1/sub-01/eeg/sub-01_eeg.edf",
+            "url": "https://nemar.s3.amazonaws.com/...?X-Amz-Expires=3600",
+        },
+    ]
+    files = _files_from_manifest(manifest, nemar_id="on1", version="v1")
+
+    assert [f.filename for f in files] == [
+        ".bidsignore",
+        "sub-01/eeg/sub-01_eeg.edf",
+    ]
+    assert files[0].checksum_algorithm == "git"
+    assert files[1].checksum == "2837b4bd"
+    assert files[1].size == 22208868
+    # `url` expires after an hour, so `bytes_url` must win.
+    assert files[1].urls == ["https://data.nemar.org/on1/v1/sub-01/eeg/sub-01_eeg.edf"]
+
+
+def test_files_from_manifest_falls_back_to_url():
+    """`url` is used when the manifest carries no `bytes_url`."""
+    files = _files_from_manifest(
+        [{"path": "a.txt", "size": 1, "url": "https://example.com/a"}],
+        nemar_id="on1",
+        version="v1",
+    )
+    assert files[0].urls == ["https://example.com/a"]
+
+
+def test_files_from_manifest_rejects_non_list():
+    """A manifest that is not a list is a bug worth reporting, not a crash."""
+    with pytest.raises(RuntimeError, match="not a list"):
+        _files_from_manifest({"nope": True}, nemar_id="on1", version="v1")
+
+
+# -- get_metadata, with the network stubbed out --
+
+
+def _fake_get_json(responses: dict[str, object]):
+    """Return a `_get_json` stub serving `responses`, keyed by URL suffix.
+
+    A URL with no entry raises `_NotFound`, standing in for NEMAR's 404.
+    """
+
+    def _stub(url: str, **kwargs: object):
+        for suffix, payload in responses.items():
+            if url.endswith(suffix):
+                return payload
+        raise _NotFound(url)
+
+    return _stub
+
+
+_KWARGS = dict(max_retries=0, retry_backoff=0.0, metadata_timeout=1.0)
+
+_MANIFEST = [
+    {
+        "path": "dataset_description.json",
+        "size": 3,
+        "checksum_algorithm": "sha256",
+        "checksum": "abc",
+        "bytes_url": "https://data.nemar.org/on004840/v1.0.0/dataset_description.json",
+    }
+]
+_METADATA = {
+    "related_identifiers": [
+        {
+            "identifier": "10.18112/openneuro.ds004840.v1.0.1",
+            "relation_type": "IsDerivedFrom",
+        }
+    ]
+}
+_VERSIONS = {"dataset_id": "on004840", "latest": "v1.0.0"}
+
+
+def test_get_metadata_reports_the_openneuro_tag():
+    """The snapshot ID carries the *OpenNeuro* tag, not NEMAR's version."""
+    responses = {
+        "/on004840/": _VERSIONS,
+        "/metadata.json": _METADATA,
+        "/manifest.json": _MANIFEST,
+    }
+    with patch.object(_nemar, "_get_json", _fake_get_json(responses)):
+        snapshot = get_metadata(dataset_id="ds004840", tag=None, **_KWARGS)
+
+    # NEMAR calls this v1.0.0; OpenNeuro calls it 1.0.1. We report the latter.
+    assert snapshot.id == "ds004840:1.0.1"
+    assert snapshot.files[0].checksum_algorithm == "sha256"
+
+
+def test_get_metadata_accepts_the_matching_tag():
+    """Requesting the OpenNeuro revision NEMAR holds succeeds."""
+    responses = {
+        "/on004840/": _VERSIONS,
+        "/metadata.json": _METADATA,
+        "/manifest.json": _MANIFEST,
+    }
+    with patch.object(_nemar, "_get_json", _fake_get_json(responses)):
+        snapshot = get_metadata(dataset_id="ds004840", tag="1.0.1", **_KWARGS)
+    assert snapshot.id == "ds004840:1.0.1"
+
+
+def test_get_metadata_rejects_a_different_tag():
+    """A revision NEMAR does not hold fails with an actionable message."""
+    responses = {
+        "/on004840/": _VERSIONS,
+        "/metadata.json": _METADATA,
+        "/manifest.json": _MANIFEST,
+    }
+    with patch.object(_nemar, "_get_json", _fake_get_json(responses)):
+        with pytest.raises(RuntimeError) as exc_info:
+            get_metadata(dataset_id="ds004840", tag="1.0.0", **_KWARGS)
+
+    message = str(exc_info.value)
+    # It must say what NEMAR *does* have, and how to get what was asked for.
+    assert "1.0.1" in message
+    assert 'source="openneuro"' in message
+
+
+def test_get_metadata_dataset_not_mirrored():
+    """A dataset NEMAR does not carry names OpenNeuro as the way out."""
+    with patch.object(_nemar, "_get_json", _fake_get_json({})):
+        with pytest.raises(RuntimeError) as exc_info:
+            get_metadata(dataset_id="ds000001", tag=None, **_KWARGS)
+
+    message = str(exc_info.value)
+    assert "ds000001 is not available from NEMAR" in message
+    assert 'source="openneuro"' in message
+
+
+def test_get_metadata_no_published_version():
+    """A listed dataset with no published version is reported clearly."""
+    responses = {"/on005691/": {"dataset_id": "on005691", "latest": None}}
+    with patch.object(_nemar, "_get_json", _fake_get_json(responses)):
+        with pytest.raises(RuntimeError, match="has not published"):
+            get_metadata(dataset_id="ds005691", tag=None, **_KWARGS)
+
+
+def test_get_metadata_unknown_provenance_without_tag(capsys):
+    """Missing provenance is survivable when no revision was requested."""
+    responses = {
+        "/on004840/": _VERSIONS,
+        "/metadata.json": {},
+        "/manifest.json": _MANIFEST,
+    }
+    with patch.object(_nemar, "_get_json", _fake_get_json(responses)):
+        snapshot = get_metadata(dataset_id="ds004840", tag=None, **_KWARGS)
+    # Falls back to NEMAR's own version, and says so.
+    assert snapshot.id == "ds004840:v1.0.0"
+
+
+def test_get_metadata_unknown_provenance_with_tag():
+    """Missing provenance is fatal when a specific revision was requested."""
+    responses = {
+        "/on004840/": _VERSIONS,
+        "/metadata.json": {},
+        "/manifest.json": _MANIFEST,
+    }
+    with patch.object(_nemar, "_get_json", _fake_get_json(responses)):
+        with pytest.raises(RuntimeError, match="does not record"):
+            get_metadata(dataset_id="ds004840", tag="1.0.1", **_KWARGS)
+
+
+def test_get_metadata_empty_manifest():
+    """An empty manifest is an error rather than a silent no-op download."""
+    responses = {
+        "/on004840/": _VERSIONS,
+        "/metadata.json": _METADATA,
+        "/manifest.json": [],
+    }
+    with patch.object(_nemar, "_get_json", _fake_get_json(responses)):
+        with pytest.raises(RuntimeError, match="lists no files"):
+            get_metadata(dataset_id="ds004840", tag=None, **_KWARGS)
+
+
+# -- _get_json --
+
+
+def _mock_session(status_code: int, json_data: object = None, json_error=None):
+    response = MagicMock()
+    response.status_code = status_code
+    response.ok = 200 <= status_code < 400
+    if json_error is not None:
+        response.json.side_effect = json_error
+    else:
+        response.json.return_value = json_data
+
+    client = MagicMock()
+    client.get.return_value = response
+    client.__enter__ = MagicMock(return_value=client)
+    client.__exit__ = MagicMock(return_value=False)
+    return client
+
+
+def test_get_json_raises_not_found_on_404():
+    """HTTP 404 becomes `_NotFound` so callers can explain it in context."""
+    with patch.object(_nemar.niquests, "Session", return_value=_mock_session(404)):
+        with pytest.raises(_NotFound):
+            _nemar._get_json(
+                "https://data.nemar.org/on1/",
+                what="testing",
+                timeout=1.0,
+                max_retries=0,
+                retry_backoff=0.0,
+            )
+
+
+def test_get_json_raises_on_other_errors():
+    """A non-retryable error status is surfaced with its code."""
+    with patch.object(_nemar.niquests, "Session", return_value=_mock_session(403)):
+        with pytest.raises(RuntimeError, match="HTTP 403"):
+            _nemar._get_json(
+                "https://data.nemar.org/on1/",
+                what="testing",
+                timeout=1.0,
+                max_retries=0,
+                retry_backoff=0.0,
+            )
+
+
+def test_get_json_retries_then_times_out():
+    """Retryable statuses are retried, and exhaustion reports a timeout."""
+    client = _mock_session(503)
+    with patch.object(_nemar.niquests, "Session", return_value=client):
+        with pytest.raises(RuntimeError, match="Timeout when testing"):
+            _nemar._get_json(
+                "https://data.nemar.org/on1/",
+                what="testing",
+                timeout=1.0,
+                max_retries=2,
+                retry_backoff=0.0,
+            )
+    assert client.get.call_count == 3  # the initial attempt plus two retries
+
+
+def test_get_json_raises_on_non_json():
+    """A non-JSON body is reported rather than propagating a decode error."""
+    client = _mock_session(200, json_error=json.JSONDecodeError("", "", 0))
+    with patch.object(_nemar.niquests, "Session", return_value=client):
+        with pytest.raises(RuntimeError, match="non-JSON"):
+            _nemar._get_json(
+                "https://data.nemar.org/on1/",
+                what="testing",
+                timeout=1.0,
+                max_retries=0,
+                retry_backoff=0.0,
+            )
+
+
+# -- checksum algorithms --
+
+
+def test_make_hasher_git_blob():
+    """The "git" algorithm is a git blob hash, not a plain SHA-1."""
+    content = b"hello world\n"
+    hasher = _make_hasher("git", size=len(content))
+    hasher.update(content)
+    expected = hashlib.sha1(b"blob %d\0" % len(content) + content).hexdigest()
+
+    assert hasher.hexdigest() == expected
+    assert hasher.hexdigest() != hashlib.sha1(content).hexdigest()
+
+
+def test_make_hasher_git_blob_requires_size():
+    """Without the size the length prefix cannot be built."""
+    with pytest.raises(ValueError, match="requires the file size"):
+        _make_hasher("git", size=None)
+
+
+@pytest.mark.parametrize(
+    ("algorithm", "reference"),
+    [("md5", hashlib.md5), ("sha256", hashlib.sha256)],
+)
+def test_make_hasher_plain_algorithms(algorithm, reference):
+    """md5 and sha256 hash the contents directly."""
+    content = b"some bytes"
+    hasher = _make_hasher(algorithm, size=len(content))
+    hasher.update(content)
+    assert hasher.hexdigest() == reference(content).hexdigest()
+
+
+def test_make_hasher_rejects_unknown():
+    """An unrecognised algorithm is refused rather than silently ignored."""
+    with pytest.raises(ValueError, match="Unknown checksum algorithm"):
+        _make_hasher("crc32", size=1)  # type: ignore[arg-type]
+
+
+# -- local revision detection across sources --
+
+
+def _write_description(path: Path, content: dict) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    (path / "dataset_description.json").write_text(json.dumps(content), "utf-8")
+
+
+def test_get_local_tag_from_nemar_directory(tmp_path: Path):
+    """NEMAR rewrites DatasetDOI, but records the source revision separately."""
+    _write_description(
+        tmp_path,
+        {
+            "DatasetDOI": "10.82901/nemar.on004840",
+            "SourceDatasets": [{"DOI": "doi:10.18112/openneuro.ds004840.v1.0.1"}],
+            "Version": "1.0.0",
+        },
+    )
+    assert _get_local_tag(dataset_id="ds004840", dataset_dir=tmp_path) == "1.0.1"
+
+
+def test_get_local_tag_from_nemar_directory_without_provenance(tmp_path: Path):
+    """A NEMAR DOI alone says nothing about the OpenNeuro revision."""
+    _write_description(tmp_path, {"DatasetDOI": "10.82901/nemar.on004840"})
+    assert _get_local_tag(dataset_id="ds004840", dataset_dir=tmp_path) is None
+
+
+def test_get_local_tag_rejects_a_different_dataset(tmp_path: Path):
+    """A NEMAR DOI for another dataset is still caught as a mismatch."""
+    _write_description(tmp_path, {"DatasetDOI": "10.82901/nemar.on000117"})
+    with pytest.raises(RuntimeError, match="appears to be different"):
+        _get_local_tag(dataset_id="ds004840", dataset_dir=tmp_path)
+
+
+def test_get_local_tag_survives_a_corrupt_description(tmp_path: Path):
+    """A damaged dataset_description.json is replaceable, not fatal.
+
+    Returning `None` lets the download re-fetch the file; raising a decode
+    error would leave the user with a directory they cannot repair.
+    """
+    (tmp_path / "dataset_description.json").write_bytes(b"\x00\x00\x00")
+    assert _get_local_tag(dataset_id="ds004840", dataset_dir=tmp_path) is None
+
+    (tmp_path / "dataset_description.json").write_text("not json", "utf-8")
+    assert _get_local_tag(dataset_id="ds004840", dataset_dir=tmp_path) is None
+
+    # A valid JSON document that is not an object is equally unusable.
+    (tmp_path / "dataset_description.json").write_text("[1, 2]", "utf-8")
+    assert _get_local_tag(dataset_id="ds004840", dataset_dir=tmp_path) is None


### PR DESCRIPTION
@bruAristimunha pointed out that NEMAR mirrors public OpenNeuro datasets. This adds an API for using NEMAR as the download source instead of openneuro-py.